### PR TITLE
fix: reject invalid network values with 400 response

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -10,6 +10,12 @@ export async function simulate(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  // Validate network parameter
+  if (network && network !== "mainnet" && network !== "testnet") {
+    res.status(400).json({ error: "Invalid network. Use 'testnet' or 'mainnet'" });
+    return;
+  }
+
   const net: Network = network === "mainnet" ? "mainnet" : "testnet";
 
   try {


### PR DESCRIPTION
closes #4 



Description:
Sending network: "MAINNET" or "futurenet" silently falls back to testnet with no warning. Callers have no way to know their network choice was ignored.