### PR TITLE
feat: add configurable request timeout middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ TESTNET_SECRET_KEY=your_testnet_secret_key_here
 PORT=3000
 NETWORK=testnet
 NODE_ENV=development
+SIMULATE_TIMEOUT_MS=30000
 
 # Grafana Configuration (for docker-compose.prod.yml)
 GRAFANA_USER=admin

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -23,7 +23,7 @@ export async function simulate(req: Request, res: Response): Promise<void> {
   metrics.incrementActiveSimulations();
 
   try {
-    const result = await simulateTransaction(xdr, net);
+    const result = await simulateTransaction(xdr, net, res.locals.abortSignal);
     
     // Record simulation metrics
     metrics.recordSimulation(net, result.success);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import dotenv from "dotenv";
 import routes from "./api/routes";
 import { metricsMiddleware, metrics } from "./middleware/metrics";
+import { timeoutMiddleware } from "./middleware/timeout";
 
 dotenv.config();
 
@@ -11,6 +12,7 @@ const PORT = process.env.PORT || 3000;
 // Middleware
 app.use(express.json());
 app.use(metricsMiddleware);
+app.use(timeoutMiddleware);
 
 // Health check endpoint
 app.get("/health", (req, res) => {

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from "express";
+
+const TIMEOUT_MS = parseInt(process.env.SIMULATE_TIMEOUT_MS ?? "30000", 10);
+
+export function timeoutMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const controller = new AbortController();
+  res.locals.abortSignal = controller.signal;
+
+  const timer = setTimeout(() => {
+    controller.abort();
+    if (!res.headersSent) {
+      res.set("Retry-After", String(Math.ceil(TIMEOUT_MS / 1000)));
+      res.status(504).json({ error: "Request timed out" });
+    }
+  }, TIMEOUT_MS);
+
+  res.on("finish", () => clearTimeout(timer));
+  next();
+}

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -18,12 +18,13 @@ export interface SimulateResult {
 export async function simulateTransaction(
   xdr: string,
   network: Network = "testnet",
+  signal?: AbortSignal,
 ): Promise<SimulateResult> {
   const server = getRpcServer(network);
   const { networkPassphrase } = getNetworkConfig(network);
 
   const tx = StellarSdk.TransactionBuilder.fromXDR(xdr, networkPassphrase);
-  const response = await server.simulateTransaction(tx);
+  const response = await server.simulateTransaction(tx, { signal } as never);
 
   if (StellarSdk.SorobanRpc.Api.isSimulationError(response)) {
     return { success: false, error: response.error, raw: response };


### PR DESCRIPTION
This PR closes #102 

Implemented changes:

Create src/middleware/timeout.ts
Use AbortController to cancel RPC call on timeout
Return 504 with Retry-After header