### PR TITLE
refactor(config): replace static configs with createNetworkConfig() f…

### DIFF
--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -1,7 +1,4 @@
 import * as StellarSdk from "@stellar/stellar-sdk";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 export type Network = "mainnet" | "testnet";
 
@@ -11,22 +8,24 @@ interface NetworkConfig {
   secretKey: string;
 }
 
-const configs: Record<Network, NetworkConfig> = {
-  mainnet: {
-    rpcUrl: process.env.MAINNET_RPC_URL || "",
-    networkPassphrase: StellarSdk.Networks.PUBLIC,
-    secretKey: process.env.MAINNET_SECRET_KEY || "",
-  },
-  testnet: {
-    rpcUrl:
-      process.env.TESTNET_RPC_URL || "https://soroban-testnet.stellar.org",
-    networkPassphrase: StellarSdk.Networks.TESTNET,
-    secretKey: process.env.TESTNET_SECRET_KEY || "",
-  },
-};
+function createNetworkConfig(): Record<Network, NetworkConfig> {
+  return {
+    mainnet: {
+      rpcUrl: process.env.MAINNET_RPC_URL || "",
+      networkPassphrase: StellarSdk.Networks.PUBLIC,
+      secretKey: process.env.MAINNET_SECRET_KEY || "",
+    },
+    testnet: {
+      rpcUrl:
+        process.env.TESTNET_RPC_URL || "https://soroban-testnet.stellar.org",
+      networkPassphrase: StellarSdk.Networks.TESTNET,
+      secretKey: process.env.TESTNET_SECRET_KEY || "",
+    },
+  };
+}
 
 export function getNetworkConfig(network: Network = "testnet"): NetworkConfig {
-  const config = configs[network];
+  const config = createNetworkConfig()[network];
   if (!config.rpcUrl) {
     throw new Error(`RPC URL not configured for network: ${network}`);
   }


### PR DESCRIPTION
## Summary                                                                                                                               
  Resolves #75 — refactors `src/config/stellar.ts` to eliminate module-level environment variable evaluation.                              
                                                                                                                                           
  ## Changes                                                                                                                               
  - Replaced static `configs` object with `createNetworkConfig()` factory function                                                         
  - All `process.env` reads now happen at call time, not module load time                                                                  
  - Removed `dotenv.config()` side effect from the config module (already called in `src/index.ts`)                                        
  - `getNetworkConfig()` public API is unchanged — no breaking changes                                                                     
                                                                                                                                           
  ## Why                                                                                                                                   
  The static `configs` object was evaluated once at import time, making it impossible to test with different env configurations without    
  module cache tricks. The factory pattern reads env vars fresh on each call, enabling straightforward test setup with `process.env.X =    
  '...'` before calling the factory.   

closes #75 