### PR TITLE
feat: add SEP-41 token contract detection to simulation response

### DIFF
--- a/src/services/footprintParser.ts
+++ b/src/services/footprintParser.ts
@@ -141,3 +141,76 @@ export function parseFootprint(footprint: {
     contracts,
   };
 }
+
+/** SEP-41 token interface required function names */
+const SEP41_FUNCTIONS = [
+  "transfer",
+  "transfer_from",
+  "burn",
+  "burn_from",
+  "balance",
+  "allowance",
+  "approve",
+  "decimals",
+  "name",
+  "symbol",
+  "total_supply",
+  "mint",
+];
+
+export type ContractType = "token" | "unknown";
+
+/** Cache of contractId → detected ContractType */
+const contractTypeCache = new Map<string, ContractType>();
+
+/**
+ * Detect whether a contract implements the SEP-41 token interface.
+ * Result is cached per contract ID.
+ *
+ * @param contractId - Hex contract ID
+ * @param server - SorobanRpc server to fetch contract code
+ * @returns "token" if SEP-41 signatures detected, otherwise "unknown"
+ */
+export async function detectTokenContract(
+  contractId: string,
+  server: StellarSdk.SorobanRpc.Server,
+): Promise<ContractType> {
+  if (contractTypeCache.has(contractId)) {
+    return contractTypeCache.get(contractId)!;
+  }
+
+  try {
+    const contractIdBytes = Uint8Array.from(
+      contractId.match(/.{2}/g)!.map((b) => parseInt(b, 16)),
+    );
+    const ledgerKey = StellarSdk.xdr.LedgerKey.contractCode(
+      new StellarSdk.xdr.LedgerKeyContractCode({
+        hash: contractIdBytes as unknown as Buffer,
+      }),
+    );
+
+    const response = await server.getLedgerEntries(ledgerKey);
+    const entry = response.entries?.[0];
+
+    if (!entry) {
+      contractTypeCache.set(contractId, "unknown");
+      return "unknown";
+    }
+
+    const ledgerEntryData = entry.val.contractCode();
+    const wasmBytes = ledgerEntryData.code() as unknown as Uint8Array;
+    const wasmText = new TextDecoder().decode(wasmBytes);
+
+    const matchCount = SEP41_FUNCTIONS.filter((fn) =>
+      wasmText.includes(fn),
+    ).length;
+
+    // Require at least 6 of the SEP-41 function names to be present
+    const result: ContractType = matchCount >= 6 ? "token" : "unknown";
+    contractTypeCache.set(contractId, result);
+    return result;
+  } catch {
+    contractTypeCache.set(contractId, "unknown");
+    return "unknown";
+  }
+}

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -3,7 +3,9 @@ import { Network, getNetworkConfig, getRpcServer } from "../config/stellar";
 import {
   parseFootprint,
   extractContracts,
+  detectTokenContract,
   type FootprintEntry,
+  type ContractType,
 } from "./footprintParser";
 import { optimizeFootprint } from "./optimizer";
 
@@ -20,6 +22,8 @@ export interface SimulateResult {
   };
   /** All unique contract IDs touched by the transaction */
   contracts?: string[];
+  /** SEP-41 token contract detection result for the invoked contract */
+  contractType?: ContractType;
   /** TTL information keyed by XDR hash */
   ttl?: Record<string, TtlInfo>;
   /** Optimization result showing redundant entries removed */
@@ -135,6 +139,12 @@ export async function simulateTransaction(
   // Fetch TTL information
   const ttl = await fetchTtlInfo(server, allXdrEntries);
 
+  // Detect SEP-41 token contract type for the first invoked contract
+  const contractType =
+    contracts.length > 0
+      ? await detectTokenContract(contracts[0], server)
+      : "unknown";
+
   return {
     success: true,
     footprint: {
@@ -142,6 +152,7 @@ export async function simulateTransaction(
       readWrite: optimizationResult.readWrite,
     },
     contracts,
+    contractType,
     ttl,
     optimized: optimizationResult.optimized,
     rawFootprint,


### PR DESCRIPTION
closes #115
- Add detectTokenContract() to footprintParser.ts with in-memory cache
- Fetch contract WASM via getLedgerEntries and scan for SEP-41 function names
- Add ContractType ('token' | 'unknown') type exported from footprintParser
- Add contractType field to SimulateResult interface in simulator.ts
- Call detectTokenContract on first invoked contract after simulation

