### PR TITLE
feat: add XDR validation endpoint POST /api/validate

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { simulateTransaction } from "../services/simulator";
 import { Network } from "../config/stellar";
 import metrics from "../middleware/metrics";
+import { validateXdr, type XdrInputType } from "../services/validator";
 
 export async function simulate(req: Request, res: Response): Promise<void> {
   const { xdr, network } = req.body as { xdr?: string; network?: Network };
@@ -40,4 +41,21 @@ export async function simulate(req: Request, res: Response): Promise<void> {
     // Decrement active simulations
     metrics.decrementActiveSimulations();
   }
+}
+
+export function validate(req: Request, res: Response): void {
+  const { xdr, type } = req.body as { xdr?: string; type?: string };
+
+  if (!xdr) {
+    res.status(400).json({ error: "Missing required field: xdr" });
+    return;
+  }
+
+  if (type && type !== "transaction" && type !== "operation") {
+    res.status(400).json({ error: "Invalid type. Use 'transaction' or 'operation'" });
+    return;
+  }
+
+  const result = validateXdr(xdr, (type as XdrInputType) ?? "transaction");
+  res.status(result.valid ? 200 : 400).json(result);
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
-import { simulate } from "./controllers";
+import { simulate, validate } from "./controllers";
 
 const router = Router();
 
 // POST /simulate — accepts { xdr, network } and returns footprint + cost
 router.post("/simulate", simulate);
+
+// POST /validate — accepts { xdr, type } and returns parse result without simulating
+router.post("/validate", validate);
 
 export default router;

--- a/src/services/validator.ts
+++ b/src/services/validator.ts
@@ -1,0 +1,60 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+export type XdrInputType = "transaction" | "operation";
+
+export interface ValidateResult {
+  valid: boolean;
+  type?: XdrInputType;
+  operationCount?: number;
+  operationType?: string;
+  error?: string;
+}
+
+export function validateXdr(
+  xdr: string,
+  type: XdrInputType = "transaction",
+): ValidateResult {
+  try {
+    if (type === "transaction") {
+      // Try both testnet and mainnet passphrases
+      let tx: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction;
+      try {
+        tx = StellarSdk.TransactionBuilder.fromXDR(
+          xdr,
+          StellarSdk.Networks.TESTNET,
+        );
+      } catch {
+        tx = StellarSdk.TransactionBuilder.fromXDR(
+          xdr,
+          StellarSdk.Networks.PUBLIC,
+        );
+      }
+
+      const ops =
+        tx instanceof StellarSdk.FeeBumpTransaction
+          ? tx.innerTransaction.operations
+          : tx.operations;
+
+      return {
+        valid: true,
+        type: "transaction",
+        operationCount: ops.length,
+        operationType: ops[0]?.type ?? "unknown",
+      };
+    } else {
+      const op = StellarSdk.xdr.Operation.fromXDR(xdr, "base64");
+      const decoded = StellarSdk.Operation.fromXDRObject(op);
+      return {
+        valid: true,
+        type: "operation",
+        operationCount: 1,
+        operationType: decoded.type,
+      };
+    }
+  } catch (err: unknown) {
+    return {
+      valid: false,
+      error: err instanceof Error ? err.message : "Failed to parse XDR",
+    };
+  }
+}


### PR DESCRIPTION
closes #116
- Create src/services/validator.ts with validateXdr()
- Parse transaction XDR (tries testnet then mainnet passphrase)
- Parse operation XDR via xdr.Operation.fromXDR
- Return { valid, type, operationCount, operationType }
- Return 400 with error details on invalid XDR
- Add validate controller and wire POST /api/validate route

