### PR TITLE
feat: add dry-run mode to skip RPC call during simulation

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -2,9 +2,14 @@ import { Request, Response } from "express";
 import { simulateTransaction } from "../services/simulator";
 import { Network } from "../config/stellar";
 import metrics from "../middleware/metrics";
+import * as StellarSdk from "@stellar/stellar-sdk";
 
 export async function simulate(req: Request, res: Response): Promise<void> {
-  const { xdr, network } = req.body as { xdr?: string; network?: Network };
+  const { xdr, network, dryRun } = req.body as {
+    xdr?: string;
+    network?: Network;
+    dryRun?: boolean;
+  };
 
   if (!xdr) {
     res.status(400).json({ error: "Missing required field: xdr" });
@@ -18,6 +23,33 @@ export async function simulate(req: Request, res: Response): Promise<void> {
   }
 
   const net: Network = network === "mainnet" ? "mainnet" : "testnet";
+
+  // Dry-run: parse XDR locally, skip RPC
+  if (dryRun) {
+    try {
+      const passphrase =
+        net === "mainnet"
+          ? StellarSdk.Networks.PUBLIC
+          : StellarSdk.Networks.TESTNET;
+      const tx = StellarSdk.TransactionBuilder.fromXDR(xdr, passphrase);
+      const ops =
+        tx instanceof StellarSdk.FeeBumpTransaction
+          ? tx.innerTransaction.operations
+          : tx.operations;
+      res.status(200).json({
+        valid: true,
+        operationCount: ops.length,
+        operationType: ops[0]?.type ?? "unknown",
+        network: net,
+      });
+    } catch (err: unknown) {
+      res.status(400).json({
+        valid: false,
+        error: err instanceof Error ? err.message : "Failed to parse XDR",
+      });
+    }
+    return;
+  }
 
   // Track active simulations
   metrics.incrementActiveSimulations();


### PR DESCRIPTION
closes #117
- Accept dryRun: true in POST /api/simulate request body
- When set, parse XDR locally and return { valid, operationCount, operationType, network }
- No RPC call is made; metrics tracking is also skipped
- Return 400 with parse error details if XDR is invalid
