### PR TITLE
feat: add optional ledger sequence parameter to simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,14 +393,16 @@ Simulate a Soroban transaction and extract its footprint.
 ```json
 {
   "xdr": "AAAAAgAAAAC...",
-  "network": "testnet"
+  "network": "testnet",
+  "ledgerSequence": 12345678
 }
 ```
 
-| Field     | Type   | Required | Description                                       |
-| --------- | ------ | -------- | ------------------------------------------------- |
-| `xdr`     | string | ✅       | Base64-encoded transaction XDR                    |
-| `network` | string | ❌       | `"testnet"` or `"mainnet"` (default: `"testnet"`) |
+| Field             | Type   | Required | Description                                                                 |
+| ----------------- | ------ | -------- | --------------------------------------------------------------------------- |
+| `xdr`             | string | ✅       | Base64-encoded transaction XDR                                              |
+| `network`         | string | ❌       | `"testnet"` or `"mainnet"` (default: `"testnet"`)                           |
+| `ledgerSequence`  | number | ❌       | Specific ledger sequence to simulate against. Useful for reproducing historical simulation results and debugging. |
 
 #### Success Response (200)
 

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -4,7 +4,11 @@ import { Network } from "../config/stellar";
 import metrics from "../middleware/metrics";
 
 export async function simulate(req: Request, res: Response): Promise<void> {
-  const { xdr, network } = req.body as { xdr?: string; network?: Network };
+  const { xdr, network, ledgerSequence } = req.body as {
+    xdr?: string;
+    network?: Network;
+    ledgerSequence?: number;
+  };
 
   if (!xdr) {
     res.status(400).json({ error: "Missing required field: xdr" });
@@ -17,13 +21,19 @@ export async function simulate(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  // Validate ledgerSequence if provided
+  if (ledgerSequence !== undefined && (!Number.isInteger(ledgerSequence) || ledgerSequence <= 0)) {
+    res.status(400).json({ error: "Invalid ledgerSequence. Must be a positive integer." });
+    return;
+  }
+
   const net: Network = network === "mainnet" ? "mainnet" : "testnet";
 
   // Track active simulations
   metrics.incrementActiveSimulations();
 
   try {
-    const result = await simulateTransaction(xdr, net, res.locals.abortSignal);
+    const result = await simulateTransaction(xdr, net, res.locals.abortSignal, ledgerSequence);
     
     // Record simulation metrics
     metrics.recordSimulation(net, result.success);

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -91,12 +91,17 @@ export async function simulateTransaction(
   xdr: string,
   network: Network = "testnet",
   signal?: AbortSignal,
+  ledgerSequence?: number,
 ): Promise<SimulateResult> {
   const server = getRpcServer(network);
   const { networkPassphrase } = getNetworkConfig(network);
 
   const tx = StellarSdk.TransactionBuilder.fromXDR(xdr, networkPassphrase);
-  const response = await server.simulateTransaction(tx, { signal } as never);
+  const simOptions: Record<string, unknown> = { signal };
+  if (ledgerSequence !== undefined) {
+    simOptions.ledger = ledgerSequence;
+  }
+  const response = await server.simulateTransaction(tx, simOptions as never);
 
   if (StellarSdk.SorobanRpc.Api.isSimulationError(response)) {
     return { success: false, error: response.error, raw: response };


### PR DESCRIPTION
## Summary

Adds an optional `ledgerSequence` field to the `POST /api/simulate` request body, allowing clients to pin simulation to a specific historical ledger.

## Changes

- **`src/services/simulator.ts`**: `simulateTransaction` now accepts an optional `ledgerSequence` parameter and passes it as `ledger` in the RPC simulation options when provided.
- **`src/api/controllers.ts`**: Extracts `ledgerSequence` from the request body, validates it is a positive integer, and forwards it to the simulator.
- **`README.md`**: API reference updated to document the new optional field.

## Usage

```json
POST /api/simulate
{
  "xdr": "AAAAAgAAAAC...",
  "network": "testnet",
  "ledgerSequence": 12345678
}

closes #114