### PR TITLE
fix: surface empty footprint as error instead of silent success

### DIFF
--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -110,10 +110,18 @@ export async function simulateTransaction(
     };
   }
 
-  const footprint = response.transactionData?.build().resources().footprint();
+  if (!response.transactionData) {
+    return {
+      success: false,
+      error: "Simulation succeeded but transactionData is missing; cannot extract footprint.",
+      raw: response,
+    };
+  }
+
+  const footprint = response.transactionData.build().resources().footprint();
   const rawFootprint = {
-    readOnly: footprint?.readOnly().map((e) => e.toXDR("base64")) ?? [],
-    readWrite: footprint?.readWrite().map((e) => e.toXDR("base64")) ?? [],
+    readOnly: footprint.readOnly().map((e) => e.toXDR("base64")),
+    readWrite: footprint.readWrite().map((e) => e.toXDR("base64")),
   };
 
   // Parse footprint entries to extract contract IDs and classify types


### PR DESCRIPTION
Check transactionData presence before extraction. Previously, optional chaining silently fell back to empty arrays when transactionData was undefined, returning success: true with an empty footprint and misleading callers. Now returns success: false with a descriptive error.

Closes #5