### PR TITLE
fix: strip internal raw field from HTTP responses

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -28,7 +28,8 @@ export async function simulate(req: Request, res: Response): Promise<void> {
     // Record simulation metrics
     metrics.recordSimulation(net, result.success);
     
-    res.status(result.success ? 200 : 422).json(result);
+    const { raw, ...clientResult } = result;
+    res.status(result.success ? 200 : 422).json(clientResult);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unexpected error";
     


### PR DESCRIPTION
Destructure raw out of SimulateResult before res.json() so internal RPC metadata, auth entries, and ledger data are never sent to callers. raw remains available within the service for logging/debugging.

Closes #6