### PR TITLE
feat: set up Jest with ts-jest for TypeScript testing

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/__tests__/**'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "solhint": "solhint 'contracts/**/*.sol'",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "prepare": "husky"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
@@ -29,8 +32,10 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
+    "jest": "^30.3.0",
     "prettier": "^3.8.3",
     "solhint": "^6.2.1",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.2",
     "validate-branch-name": "^1.3.2"

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -1,0 +1,10 @@
+describe('Smoke Test', () => {
+  it('should verify that Jest is working', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('should verify that TypeScript is supported', () => {
+    const message: string = 'Hello, TypeScript!';
+    expect(message).toBe('Hello, TypeScript!');
+  });
+});


### PR DESCRIPTION
I have successfully set up Jest with ts-jest for the Stellar-Footprint-Service project.

closes #42 