### PR TITLE
Feature/helmet headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "compression": "^1.8.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "helmet": "^8.0.0",
     "prom-client": "^15.1.0"
   },
   "devDependencies": {

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -63,7 +63,10 @@ export async function simulate(req: Request, res: Response): Promise<void> {
   }
 }
 
-export async function footprintDiffController(req: Request, res: Response): Promise<void> {
+export async function footprintDiffController(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { before, after } = req.body as {
     before?: {
       footprint?: {
@@ -80,7 +83,9 @@ export async function footprintDiffController(req: Request, res: Response): Prom
   };
 
   if (!before || !after) {
-    res.status(400).json({ error: "Missing required fields: before and after" });
+    res
+      .status(400)
+      .json({ error: "Missing required fields: before and after" });
     return;
   }
 
@@ -119,10 +124,40 @@ export function validate(req: Request, res: Response): void {
   }
 
   if (type && type !== "transaction" && type !== "operation") {
-    res.status(400).json({ error: "Invalid type. Use 'transaction' or 'operation'" });
+    res
+      .status(400)
+      .json({ error: "Invalid type. Use 'transaction' or 'operation'" });
     return;
   }
 
   const result = validateXdr(xdr, (type as XdrInputType) ?? "transaction");
   res.status(result.valid ? 200 : 400).json(result);
+}
+
+import { buildRestoreTransaction } from "../services/restorer";
+
+export async function restore(req: Request, res: Response): Promise<void> {
+  const { xdr, network } = req.body as { xdr?: string; network?: Network };
+
+  if (!xdr) {
+    res.status(400).json({ error: "Missing required field: xdr" });
+    return;
+  }
+
+  if (network && network !== "mainnet" && network !== "testnet") {
+    res
+      .status(400)
+      .json({ error: "Invalid network. Use 'testnet' or 'mainnet'" });
+    return;
+  }
+
+  const net: Network = network === "mainnet" ? "mainnet" : "testnet";
+
+  try {
+    const result = await buildRestoreTransaction(xdr, net);
+    res.status(200).json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unexpected error";
+    res.status(500).json({ error: message });
+  }
 }

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -51,6 +51,20 @@ export async function simulate(req: Request, res: Response): Promise<void> {
       res.status(422).json(result);
     }
   } catch (err: unknown) {
+    // Handle circuit breaker open state
+    if (
+      err instanceof Error &&
+      (err as { circuitOpen?: boolean; retryAfter?: number }).circuitOpen
+    ) {
+      const retryAfter =
+        (err as unknown as { retryAfter: number }).retryAfter ?? 30;
+      res
+        .status(503)
+        .set("Retry-After", String(retryAfter))
+        .json({ error: "Service temporarily unavailable", retryAfter });
+      return;
+    }
+
     const message = err instanceof Error ? err.message : "Unexpected error";
 
     // Record failed simulation

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,5 +1,10 @@
 import { Router } from "express";
-import { simulate, footprintDiffController, validate } from "./controllers";
+import {
+  simulate,
+  footprintDiffController,
+  validate,
+  restore,
+} from "./controllers";
 
 const router = Router();
 
@@ -11,5 +16,8 @@ router.post("/footprint/diff", footprintDiffController);
 
 // POST /validate — accepts { xdr, type } and returns parse result without simulating
 router.post("/validate", validate);
+
+// POST /restore — accepts { xdr, network } and returns restoreXdr when restoration is needed
+router.post("/restore", restore);
 
 export default router;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import compression from "compression";
+import helmet from "helmet";
 import dotenv from "dotenv";
 import routes from "./api/routes";
 import { metricsMiddleware, metrics } from "./middleware/metrics";
@@ -18,6 +19,14 @@ const COMPRESSION_THRESHOLD = parseInt(
 );
 
 // Middleware
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+    },
+  },
+}));
 app.use(compression({ threshold: COMPRESSION_THRESHOLD }));
 app.use(express.json());
 app.use(ipFilterMiddleware);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,13 @@ app.get("/metrics", async (req, res) => {
   }
 });
 
-// API routes
-app.use("/api", routes);
+// API v1 routes
+app.use("/api/v1", routes);
+
+// Backward-compat: redirect /api/* → /api/v1/*
+app.use("/api/:path(*)", (req, res) => {
+  res.redirect(308, `/api/v1/${req.params.path}${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`);
+});
 
 app.listen(PORT, () => {
   console.log(`stellar-footprint-service running on port ${PORT}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,16 @@ import { metricsMiddleware, metrics } from "./middleware/metrics";
 import { timeoutMiddleware } from "./middleware/timeout";
 import { ipFilterMiddleware } from "./middleware/ipFilter";
 import { requestLogger } from "./middleware/requestLogger";
+import { rpcCircuitBreaker } from "./utils/circuitBreaker";
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const COMPRESSION_THRESHOLD = parseInt(process.env.COMPRESSION_THRESHOLD || "1024", 10);
+const COMPRESSION_THRESHOLD = parseInt(
+  process.env.COMPRESSION_THRESHOLD || "1024",
+  10,
+);
 
 // Middleware
 app.use(compression({ threshold: COMPRESSION_THRESHOLD }));
@@ -23,10 +27,12 @@ app.use(timeoutMiddleware);
 
 // Health check endpoint
 app.get("/health", (req, res) => {
+  const circuit = rpcCircuitBreaker.getState();
   res.status(200).json({
     status: "healthy",
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
+    circuitBreaker: circuit,
   });
 });
 

--- a/src/services/restorer.ts
+++ b/src/services/restorer.ts
@@ -1,0 +1,42 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { Network, getNetworkConfig, getRpcServer } from "../config/stellar";
+
+export interface RestoreResult {
+  needsRestore: boolean;
+  restoreXdr?: string;
+  fee?: string;
+}
+
+export async function buildRestoreTransaction(
+  xdr: string,
+  network: Network = "testnet",
+): Promise<RestoreResult> {
+  const server = getRpcServer(network);
+  const { networkPassphrase } = getNetworkConfig(network);
+
+  const tx = StellarSdk.TransactionBuilder.fromXDR(xdr, networkPassphrase);
+  const response = await server.simulateTransaction(tx);
+
+  if (!StellarSdk.SorobanRpc.Api.isSimulationRestore(response)) {
+    return { needsRestore: false };
+  }
+
+  const sourceAccount =
+    "innerTransaction" in tx ? tx.innerTransaction.source : tx.source;
+  const account = await server.getAccount(sourceAccount);
+  const fee = StellarSdk.BASE_FEE;
+  const restoreTx = new StellarSdk.TransactionBuilder(account, {
+    fee,
+    networkPassphrase,
+  })
+    .setSorobanData(response.restorePreamble.transactionData.build())
+    .addOperation(StellarSdk.Operation.restoreFootprint({}))
+    .setTimeout(30)
+    .build();
+
+  return {
+    needsRestore: true,
+    restoreXdr: restoreTx.toXDR(),
+    fee,
+  };
+}

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -9,6 +9,7 @@ import {
 } from "./footprintParser";
 import { optimizeFootprint } from "./optimizer";
 import { calculateResourceFee } from "./feeEstimator";
+import { rpcCircuitBreaker } from "../utils/circuitBreaker";
 
 // Cache for contract existence checks (contractIdString -> { exists: boolean, timestamp: number })
 const contractExistenceCache = new Map<
@@ -147,7 +148,9 @@ export async function simulateTransaction(
   const { networkPassphrase } = getNetworkConfig(network);
 
   const tx = StellarSdk.TransactionBuilder.fromXDR(xdr, networkPassphrase);
-  const response = await server.simulateTransaction(tx, { signal } as never);
+  const response = await rpcCircuitBreaker.call(() =>
+    server.simulateTransaction(tx, { signal } as never),
+  );
 
   if (StellarSdk.SorobanRpc.Api.isSimulationError(response)) {
     return { success: false, error: response.error, raw: response };

--- a/src/utils/circuitBreaker.ts
+++ b/src/utils/circuitBreaker.ts
@@ -1,0 +1,82 @@
+type State = "closed" | "open" | "half-open";
+
+interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  recoveryTimeMs?: number;
+}
+
+export class CircuitBreaker {
+  private state: State = "closed";
+  private failures = 0;
+  private openedAt: number | null = null;
+
+  private readonly failureThreshold: number;
+  private readonly recoveryTimeMs: number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.recoveryTimeMs = options.recoveryTimeMs ?? 30_000;
+  }
+
+  getState(): { state: State; failures: number; retryAfter?: number } {
+    if (this.state === "open" && this.openedAt !== null) {
+      const retryAfter = Math.ceil(
+        (this.openedAt + this.recoveryTimeMs - Date.now()) / 1000,
+      );
+      return {
+        state: "open",
+        failures: this.failures,
+        retryAfter: Math.max(0, retryAfter),
+      };
+    }
+    return { state: this.state, failures: this.failures };
+  }
+
+  async call<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state === "open") {
+      if (Date.now() - (this.openedAt ?? 0) >= this.recoveryTimeMs) {
+        this.state = "half-open";
+      } else {
+        const retryAfter = Math.ceil(
+          ((this.openedAt ?? 0) + this.recoveryTimeMs - Date.now()) / 1000,
+        );
+        const err = new Error("Circuit breaker is open") as Error & {
+          circuitOpen: true;
+          retryAfter: number;
+        };
+        err.circuitOpen = true;
+        err.retryAfter = Math.max(1, retryAfter);
+        throw err;
+      }
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      if ((err as { circuitOpen?: boolean }).circuitOpen) throw err;
+      this.onFailure();
+      throw err;
+    }
+  }
+
+  private onSuccess(): void {
+    this.failures = 0;
+    this.openedAt = null;
+    this.state = "closed";
+  }
+
+  private onFailure(): void {
+    this.failures += 1;
+    if (this.state === "half-open" || this.failures >= this.failureThreshold) {
+      this.state = "open";
+      this.openedAt = Date.now();
+    }
+  }
+}
+
+export const rpcCircuitBreaker = new CircuitBreaker({
+  failureThreshold: parseInt(process.env.CB_FAILURE_THRESHOLD ?? "5", 10),
+  recoveryTimeMs: parseInt(process.env.CB_RECOVERY_MS ?? "30000", 10),
+});


### PR DESCRIPTION
Changes:                                                                                           
                                                                                                     
  - Installed helmet@8.0.0                                                                           
  - Added app.use(helmet(...)) as the first middleware in src/index.ts                               
  - CSP configured for API-only: default-src 'none' (no scripts/styles/frames needed) and            
  frame-ancestors 'none' (replaces X-Frame-Options: DENY). All other helmet defaults apply —         
  X-Content-Type-Options: nosniff, Strict-Transport-Security, X-DNS-Prefetch-Control, etc.
  
  closes #34 