### PR TITLE
test: add XDR test fixtures for use across test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "prepare": "husky"
   },
   "dependencies": {
-<<<<<<< HEAD
     "@stellar/stellar-sdk": "^12.0.0",
     "compression": "^1.8.1",
     "dotenv": "^17.4.2",
@@ -46,27 +45,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "validate-branch-name": "^1.3.2"
-=======
-    "@stellar/stellar-sdk": "12.0.0",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-    "prom-client": "15.1.0"
-  },
-  "devDependencies": {
-    "@types/express": "4.17.21",
-    "@types/node": "20.10.0",
-    "@typescript-eslint/eslint-plugin": "8.58.2",
-    "@typescript-eslint/parser": "8.58.2",
-    "eslint": "10.2.1",
-    "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-prettier": "5.5.5",
-    "husky": "9.1.7",
-    "prettier": "3.8.3",
-    "solhint": "6.2.1",
-    "ts-node": "10.9.2",
-    "typescript": "5.3.2",
-    "validate-branch-name": "1.3.2"
->>>>>>> 83236b6 (chore: implement CI improvements and dependency management)
   },
   "validate-branch-name": {
     "pattern": "^(main|develop|live)$|^(feature|fix|refactor|hotfix|release|conflict|chore)/.+$",

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -36,7 +36,8 @@ async function checkContractExists(
 
   try {
     // Convert contractIdString to LedgerKey for an account
-    const accountId = StellarSdk.xdr.AccountId.fromString(contractIdString);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const accountId = (StellarSdk.xdr as any).AccountId.fromString(contractIdString);
     const ledgerKey = StellarSdk.xdr.LedgerKey.account(accountId);
     const response = await server.getLedgerEntries(ledgerKey);
     const exists = response.entries && response.entries.length > 0;

--- a/src/services/tests/simulator.test.ts
+++ b/src/services/tests/simulator.test.ts
@@ -1,9 +1,16 @@
 import { simulateTransaction } from "../simulator";
+import {
+  SOROBAN_INVOKE_XDR,
+  CLASSIC_PAYMENT_XDR,
+  FEE_BUMP_XDR,
+  INVALID_BASE64_XDR,
+  INVALID_XDR_BYTES,
+} from "../../tests/fixtures/xdr";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
-const mockSimulateTransaction = jest.fn();
-const mockGetLedgerEntries = jest.fn();
+// jest.mock factories are hoisted before variable declarations, so all mock
+// functions must be created inside the factory (not referenced from outside).
 
 jest.mock("../../config/stellar", () => ({
   getNetworkConfig: jest.fn().mockReturnValue({
@@ -11,11 +18,49 @@ jest.mock("../../config/stellar", () => ({
     rpcUrl: "https://soroban-testnet.stellar.org",
     secretKey: "",
   }),
-  getRpcServer: jest.fn().mockReturnValue({
-    simulateTransaction: mockSimulateTransaction,
-    getLedgerEntries: mockGetLedgerEntries,
-  }),
+  getRpcServer: jest.fn(),
 }));
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  TransactionBuilder: {
+    fromXDR: jest.fn().mockReturnValue({}),
+  },
+  SorobanRpc: {
+    Server: jest.fn(),
+    Api: {
+      isSimulationError: jest.fn(),
+      isSimulationRestore: jest.fn(),
+    },
+  },
+  Networks: {
+    TESTNET: "Test SDF Network ; September 2015",
+    PUBLIC: "Public Global Stellar Network ; September 2015",
+  },
+  xdr: {
+    LedgerKey: {
+      fromXDR: jest.fn().mockReturnValue({}),
+      account: jest.fn().mockReturnValue({}),
+      contractCode: jest.fn().mockReturnValue({}),
+    },
+    AccountId: { fromString: jest.fn().mockReturnValue({}) },
+  },
+}));
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getRpcServer } from "../../config/stellar";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Use the shared fixture; kept as an alias so existing tests are unchanged.
+const DUMMY_XDR = INVALID_XDR_BYTES;
+
+// Stable mock server — getRpcServer always returns this same object.
+const mockSimulateTransaction = jest.fn();
+const mockGetLedgerEntries = jest.fn();
+const mockServer = {
+  simulateTransaction: mockSimulateTransaction,
+  getLedgerEntries: mockGetLedgerEntries,
+};
 
 // Minimal XDR footprint builder helpers
 const mockFootprint = {
@@ -26,46 +71,6 @@ const mockResources = jest.fn().mockReturnValue({ footprint: () => mockFootprint
 const mockBuild = jest.fn().mockReturnValue({ resources: mockResources, auth: jest.fn().mockReturnValue([]) });
 const mockTransactionData = { build: mockBuild };
 
-const mockTx = {};
-
-jest.mock("@stellar/stellar-sdk", () => {
-  const isSimulationError = jest.fn();
-  const isSimulationRestore = jest.fn();
-
-  return {
-    TransactionBuilder: {
-      fromXDR: jest.fn().mockReturnValue(mockTx),
-    },
-    SorobanRpc: {
-      Server: jest.fn(),
-      Api: { isSimulationError, isSimulationRestore },
-    },
-    Networks: {
-      TESTNET: "Test SDF Network ; September 2015",
-      PUBLIC: "Public Global Stellar Network ; September 2015",
-    },
-    xdr: {
-      LedgerKey: {
-        fromXDR: jest.fn().mockReturnValue({}),
-        account: jest.fn().mockReturnValue({}),
-        contractCode: jest.fn().mockReturnValue({}),
-      },
-      AccountId: { fromString: jest.fn().mockReturnValue({}) },
-    },
-  };
-});
-
-import * as StellarSdk from "@stellar/stellar-sdk";
-
-const isSimulationError = StellarSdk.SorobanRpc.Api
-  .isSimulationError as jest.Mock;
-const isSimulationRestore = StellarSdk.SorobanRpc.Api
-  .isSimulationRestore as jest.Mock;
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-const DUMMY_XDR = "AAAAAA==";
-
 function makeSuccessResponse() {
   return {
     transactionData: mockTransactionData,
@@ -74,10 +79,14 @@ function makeSuccessResponse() {
   };
 }
 
+const isSimulationError = StellarSdk.SorobanRpc.Api.isSimulationError as unknown as jest.Mock;
+const isSimulationRestore = StellarSdk.SorobanRpc.Api.isSimulationRestore as unknown as jest.Mock;
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
   jest.clearAllMocks();
+  (getRpcServer as jest.Mock).mockReturnValue(mockServer);
   isSimulationError.mockReturnValue(false);
   isSimulationRestore.mockReturnValue(false);
   mockGetLedgerEntries.mockResolvedValue({ entries: [], latestLedger: 100 });
@@ -165,11 +174,47 @@ describe("simulateTransaction", () => {
   });
 
   it("uses mainnet network config when network is mainnet", async () => {
-    const { getRpcServer } = jest.requireMock("../../config/stellar");
     mockSimulateTransaction.mockResolvedValue(makeSuccessResponse());
 
     await simulateTransaction(DUMMY_XDR, "mainnet");
 
     expect(getRpcServer).toHaveBeenCalledWith("mainnet");
+  });
+
+  // ── Fixture-based tests ───────────────────────────────────────────────────
+
+  it("accepts SOROBAN_INVOKE_XDR fixture and returns success", async () => {
+    mockSimulateTransaction.mockResolvedValue(makeSuccessResponse());
+
+    const result = await simulateTransaction(SOROBAN_INVOKE_XDR, "testnet");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts CLASSIC_PAYMENT_XDR fixture without throwing", async () => {
+    mockSimulateTransaction.mockResolvedValue(makeSuccessResponse());
+
+    const result = await simulateTransaction(CLASSIC_PAYMENT_XDR, "testnet");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts FEE_BUMP_XDR fixture without throwing", async () => {
+    mockSimulateTransaction.mockResolvedValue(makeSuccessResponse());
+
+    const result = await simulateTransaction(FEE_BUMP_XDR, "testnet");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("propagates error when INVALID_BASE64_XDR is passed to the SDK", async () => {
+    const { TransactionBuilder } = jest.requireMock("@stellar/stellar-sdk");
+    TransactionBuilder.fromXDR.mockImplementationOnce(() => {
+      throw new Error("invalid base64");
+    });
+
+    await expect(
+      simulateTransaction(INVALID_BASE64_XDR, "testnet"),
+    ).rejects.toThrow("invalid base64");
   });
 });

--- a/src/tests/fixtures/xdr.ts
+++ b/src/tests/fixtures/xdr.ts
@@ -1,0 +1,40 @@
+/**
+ * XDR test fixtures for use across the test suite.
+ *
+ * All transaction XDRs are signed against the Stellar Testnet passphrase
+ * ("Test SDF Network ; September 2015") and are structurally valid but
+ * not submitted to any network.
+ */
+
+/**
+ * A valid Soroban InvokeHostFunction transaction XDR.
+ * Calls a no-op "hello" method on a placeholder contract.
+ */
+export const SOROBAN_INVOKE_XDR =
+  "AAAAAgAAAACnDQTKOBdaOH0ynf6k7SpkytahlUjNsWgm4WEB8rmE1QAAAGQAAAAAAAAAZwAAAAEAAAAAAAAAAAAAAABp6joKAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFaGVsbG8AAAAAAAABAAAAAQAAAAAAAAAAAAAAAfK5hNUAAABAIbPVF4x6vSLx/J3T0SDhvTNtytA/BNO+qMJ74p/b3Y8xpBhR7xzy68FuEyffaF9fNXHEC+77WK+oOJpfon1tCg==";
+
+/**
+ * A valid classic payment transaction XDR (non-Soroban).
+ * Sends 10 XLM on testnet. Useful for testing rejection of non-Soroban ops.
+ */
+export const CLASSIC_PAYMENT_XDR =
+  "AAAAAgAAAACnDQTKOBdaOH0ynf6k7SpkytahlUjNsWgm4WEB8rmE1QAAAGQAAAAAAAAAZQAAAAEAAAAAAAAAAAAAAABp6joKAAAAAAAAAAEAAAAAAAAAAQAAAACBuBB++TgKRxys9exytXimf/beipQQ56MDmtwaAqCClQAAAAAAAAAABfXhAAAAAAAAAAAB8rmE1QAAAEDLHQ6k5b2ZZDkoKTkUFcXdVlvVpjecSQDVINepYzOOLh9OCPM9CHnao2RfXNliTyv5J2VjoWsBxtdntLINUAUP";
+
+/**
+ * A valid fee-bump transaction XDR wrapping a classic payment.
+ * Useful for testing that fee-bump envelopes are handled correctly.
+ */
+export const FEE_BUMP_XDR =
+  "AAAABQAAAACnDQTKOBdaOH0ynf6k7SpkytahlUjNsWgm4WEB8rmE1QAAAAAAAAGQAAAAAgAAAACnDQTKOBdaOH0ynf6k7SpkytahlUjNsWgm4WEB8rmE1QAAAGQAAAAAAAAAZgAAAAEAAAAAAAAAAAAAAABp6joKAAAAAAAAAAEAAAAAAAAAAQAAAACBuBB++TgKRxys9exytXimf/beipQQ56MDmtwaAqCClQAAAAAAAAAAAJiWgAAAAAAAAAAB8rmE1QAAAED+Bgzaei9jKakVUEpzuxCzO+Ps6rcBrrY7iBKfbnVzMEvWgrXfP1t0/5nry7+kqnRcwZlvOjhIkjaQ9s5Eu1cNAAAAAAAAAAHyuYTVAAAAQBwYHIR+QQkizIFaGmqycFTIcz6dbXv2X3IKGf7CpyCrqdudR/dhMrzrs4EVeFiZEvLPAoc7EUHT43PUy/LWNQ0=";
+
+/**
+ * An invalid base64 string — not valid XDR at all.
+ * Useful for testing input validation and parse-error handling.
+ */
+export const INVALID_BASE64_XDR = "not-valid-base64!!!@@@";
+
+/**
+ * A structurally valid base64 string that does not decode to valid XDR.
+ * Useful for testing XDR parse failures distinct from base64 decode failures.
+ */
+export const INVALID_XDR_BYTES = "AAAAAA==";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Closes #47

Adds a shared XDR fixtures file at `src/tests/fixtures/xdr.ts` with named constants for use across the test suite.

## Fixtures added

| Export | Description |
|--------|-------------|
| `SOROBAN_INVOKE_XDR` | Valid Soroban `InvokeHostFunction` transaction (testnet) |
| `CLASSIC_PAYMENT_XDR` | Valid classic payment transaction (testnet) |
| `FEE_BUMP_XDR` | Valid fee-bump transaction wrapping a classic payment (testnet) |
| `INVALID_BASE64_XDR` | Invalid base64 string — not valid XDR |
| `INVALID_XDR_BYTES` | Valid base64 that does not decode to valid XDR |

## Changes

- **`src/tests/fixtures/xdr.ts`** — new fixtures file (all XDRs are real, SDK-generated, testnet-signed)
- **`src/services/tests/simulator.test.ts`** — imports fixtures; adds 4 fixture-based tests; fixes pre-existing jest.mock hoisting issues
- **`package.json`** — resolves merge conflict (kept HEAD with jest/ts-jest)
- **`tsconfig.json`** — adds `"types": ["jest", "node"]` so TypeScript recognises jest globals
- **`src/services/simulator.ts`** — adds `as any` cast for `xdr.AccountId` (missing from SDK type definitions)

## Testing

All 15 tests pass:
```
PASS src/services/tests/simulator.test.ts
PASS src/__tests__/smoke.test.ts

Tests: 15 passed, 15 total
```