### PR TITLE
feat: add autocannon load testing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,50 @@ npm install
 cp .env.example .env
 # Edit .env with your RPC URLs and keys
 ```
+## Load Testing
+
+To benchmark the service under concurrent load:
+
+1. Start the local server:
+   ```bash
+   npm run dev
+   ```
+2. Run the autocannon load test:
+   ```bash
+   npm run load-test
+   ```
+
+### What is tested
+
+This load test runs three concurrency levels against the service:
+
+- `10` connections
+- `50` connections
+- `100` connections
+
+### Metrics explained
+
+- `p50`: median latency, meaning half of requests completed faster than this value.
+- `p95`: latency at the 95th percentile, showing how slow the slowest 5% of requests are.
+- `p99`: latency at the 99th percentile, showing the tail latency for the slowest 1% of requests.
+- `Req/sec`: average number of successful requests per second.
+- `Errors(%)`: percentage of requests that failed, timed out, or returned non-2xx responses.
+
+### How to interpret results
+
+- Lower `p50`, `p95`, and `p99` values indicate better request latency.
+- A small gap between `p95` and `p99` suggests a stable service under load.
+- A low `Errors(%)` means the service handled the traffic reliably.
+
+### Customize the target
+
+By default, the load test targets the health endpoint at `http://localhost:3000/health`.
+
+You can override the base URL using `LOAD_TEST_URL` or change the path via `LOAD_TEST_PATH`:
+
+```bash
+LOAD_TEST_URL=http://localhost:3000 LOAD_TEST_PATH=/metrics npm run load-test
+```
 
 ### Scaffold from Scratch
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "solhint": "solhint 'contracts/**/*.sol'",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "prepare": "husky"
+    "prepare": "husky",
+    "load-test": "node scripts/load-test.js"
   },
   "dependencies": {
-<<<<<<< HEAD
     "@stellar/stellar-sdk": "^12.0.0",
     "compression": "^1.8.1",
     "dotenv": "^17.4.2",
@@ -35,6 +35,7 @@
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.59.0",
+    "autocannon": "^8.0.0",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
@@ -46,27 +47,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "validate-branch-name": "^1.3.2"
-=======
-    "@stellar/stellar-sdk": "12.0.0",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-    "prom-client": "15.1.0"
-  },
-  "devDependencies": {
-    "@types/express": "4.17.21",
-    "@types/node": "20.10.0",
-    "@typescript-eslint/eslint-plugin": "8.58.2",
-    "@typescript-eslint/parser": "8.58.2",
-    "eslint": "10.2.1",
-    "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-prettier": "5.5.5",
-    "husky": "9.1.7",
-    "prettier": "3.8.3",
-    "solhint": "6.2.1",
-    "ts-node": "10.9.2",
-    "typescript": "5.3.2",
-    "validate-branch-name": "1.3.2"
->>>>>>> 83236b6 (chore: implement CI improvements and dependency management)
   },
   "validate-branch-name": {
     "pattern": "^(main|develop|live)$|^(feature|fix|refactor|hotfix|release|conflict|chore)/.+$",

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -1,0 +1,72 @@
+const autocannon = require("autocannon");
+
+const baseUrl = process.env.LOAD_TEST_URL || "http://localhost:3000";
+const defaultPath = process.env.LOAD_TEST_PATH || "/health";
+const target = new URL(defaultPath, baseUrl).toString();
+const duration = parseInt(process.env.LOAD_TEST_DURATION || "25", 10);
+const scenarios = [10, 50, 100];
+
+function formatNumber(value) {
+  return String(value).padStart(5, " ");
+}
+
+function calculateErrorRate(result) {
+  const totalRequests = result.requests?.total ?? 0;
+  const totalErrors = (result.errors ?? 0) + (result.timeouts ?? 0) + (result.non2xx ?? 0);
+  return totalRequests > 0 ? (totalErrors / totalRequests) * 100 : 0;
+}
+
+async function runScenario(connections) {
+  console.log(`\nRunning load test: ${connections} connections for ${duration}s against ${target}`);
+
+  const result = await autocannon({
+    url: target,
+    connections,
+    duration,
+    timeout: 30000,
+  });
+
+  return {
+    connections,
+    p50: Math.round(result.latency?.p50 ?? 0),
+    p95: Math.round(result.latency?.p95 ?? 0),
+    p99: Math.round(result.latency?.p99 ?? 0),
+    reqPerSec: Math.round(result.requests?.average ?? 0),
+    errors: calculateErrorRate(result).toFixed(2),
+  };
+}
+
+function printSummary(results) {
+  const header = "Connections | p50(ms) | p95(ms) | p99(ms) | Req/sec | Errors(%)";
+  const divider = "---------------------------------------------------------------";
+
+  console.log("\nLoad Test Summary");
+  console.log(header);
+  console.log(divider);
+
+  results.forEach((row) => {
+    console.log(
+      `${String(row.connections).padEnd(11)} | ${formatNumber(row.p50).padEnd(7)} | ${formatNumber(row.p95).padEnd(7)} | ${formatNumber(row.p99).padEnd(7)} | ${formatNumber(row.reqPerSec).padEnd(7)} | ${String(row.errors).padStart(8)}`
+    );
+  });
+}
+
+async function runLoadTests() {
+  try {
+    console.log("Starting autocannon load tests...");
+    const results = [];
+
+    for (const connections of scenarios) {
+      const result = await runScenario(connections);
+      results.push(result);
+    }
+
+    printSummary(results);
+    process.exit(0);
+  } catch (error) {
+    console.error("Load test failed:", error);
+    process.exit(1);
+  }
+}
+
+runLoadTests();


### PR DESCRIPTION
Closes #49 

This PR adds a reusable load testing script using autocannon and a new npm script `npm run load-test`.

### Load Test Results

| Connections | p50 | p95 | p99 | Req/sec | Errors |
|------------|-----|-----|-----|---------|--------|
| 10         | 0   | 0   | 3   | 8231    | 0.00   |
| 50         | 5   | 0   | 13  | 8756    | 0.00   |
| 100        | 10  | 0   | 28  | 8557    | 0.00   |