### PR TITLE
feature:Add mock Stellar RPC server for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,39 +21,16 @@
     "prepare": "husky"
   },
   "dependencies": {
-<<<<<<< HEAD
-    "@stellar/stellar-sdk": "^12.0.0",
-    "compression": "^1.8.1",
-    "dotenv": "^17.4.2",
-    "express": "^5.2.1",
-    "prom-client": "^15.1.0"
-  },
-  "devDependencies": {
-    "@types/compression": "^1.8.1",
-    "@types/express": "^5.0.6",
-    "@types/jest": "^30.0.0",
-    "@types/node": "^25.6.0",
-    "@typescript-eslint/eslint-plugin": "^8.58.2",
-    "@typescript-eslint/parser": "^8.59.0",
-    "eslint": "^10.2.1",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.5",
-    "husky": "^9.1.7",
-    "jest": "^30.3.0",
-    "prettier": "^3.8.3",
-    "solhint": "^6.2.1",
-    "ts-jest": "^29.4.9",
-    "ts-node": "^10.9.2",
-    "typescript": "^6.0.3",
-    "validate-branch-name": "^1.3.2"
-=======
     "@stellar/stellar-sdk": "12.0.0",
+    "compression": "1.7.4",
     "dotenv": "16.3.1",
     "express": "4.18.2",
     "prom-client": "15.1.0"
   },
   "devDependencies": {
+    "@types/compression": "1.7.5",
     "@types/express": "4.17.21",
+    "@types/jest": "29.5.11",
     "@types/node": "20.10.0",
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
@@ -61,12 +38,13 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
     "husky": "9.1.7",
+    "jest": "29.7.0",
     "prettier": "3.8.3",
     "solhint": "6.2.1",
+    "ts-jest": "29.1.1",
     "ts-node": "10.9.2",
     "typescript": "5.3.2",
     "validate-branch-name": "1.3.2"
->>>>>>> 83236b6 (chore: implement CI improvements and dependency management)
   },
   "validate-branch-name": {
     "pattern": "^(main|develop|live)$|^(feature|fix|refactor|hotfix|release|conflict|chore)/.+$",

--- a/src/tests/integration/simulator.integration.test.ts
+++ b/src/tests/integration/simulator.integration.test.ts
@@ -1,0 +1,240 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { simulateTransaction } from "../../services/simulator";
+import { startMockRpcServer, MockRpcServerInstance } from "../mocks/rpcServer";
+
+/**
+ * Integration tests for simulateTransaction using mock RPC server
+ * Tests real SDK behavior without network access
+ */
+describe("simulateTransaction Integration Tests", () => {
+  let mockRpc: MockRpcServerInstance;
+
+  beforeAll(async () => {
+    mockRpc = await startMockRpcServer();
+  });
+
+  afterAll(async () => {
+    await mockRpc.stop();
+  });
+
+  beforeEach(() => {
+    // Reset to default success response before each test
+    mockRpc.configure({ responseType: "success" });
+    // Override RPC URL via environment variable
+    process.env.TESTNET_RPC_URL = mockRpc.url;
+  });
+
+  /**
+   * Helper to create a minimal valid Soroban transaction XDR
+   * This creates a real transaction that the SDK can parse
+   */
+  function createMinimalSorobanTxXdr(): string {
+    const sourceKeypair = StellarSdk.Keypair.random();
+    const account = new StellarSdk.Account(sourceKeypair.publicKey(), "0");
+
+    const contract = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+    const operation = StellarSdk.Operation.invokeHostFunction({
+      func: StellarSdk.xdr.HostFunction.hostFunctionTypeInvokeContract(
+        new StellarSdk.xdr.InvokeContractArgs({
+          contractAddress: StellarSdk.Address.fromString(contract).toXDRObject(),
+          functionName: Buffer.from("test"),
+          args: [],
+        }),
+      ),
+      auth: [],
+    });
+
+    const tx = new StellarSdk.TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: StellarSdk.Networks.TESTNET_FUTURE,
+      v1: true,
+    })
+      .addOperation(operation)
+      .setTimeout(30)
+      .build();
+
+    return tx.toXDR();
+  }
+
+  describe("Success Scenarios", () => {
+    it("should simulate transaction successfully with mock RPC", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(true);
+      expect(result.footprint).toBeDefined();
+      expect(result.footprint?.readOnly).toBeDefined();
+      expect(result.footprint?.readWrite).toBeDefined();
+      expect(result.cost).toBeDefined();
+      expect(result.cost?.cpuInsns).toBeDefined();
+      expect(result.cost?.memBytes).toBeDefined();
+    });
+
+    it("should return footprint with parsed entries", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(true);
+      expect(Array.isArray(result.footprint?.readOnly)).toBe(true);
+      expect(Array.isArray(result.footprint?.readWrite)).toBe(true);
+    });
+
+    it("should include raw response in result", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.raw).toBeDefined();
+      expect(result.raw?.transactionData).toBeDefined();
+    });
+
+    it("should handle custom ledger sequence", async () => {
+      mockRpc.configure({ responseType: "success", ledgerSequence: 5000 });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet", undefined, 5000);
+
+      expect(result.success).toBe(true);
+      expect(result.raw?.latestLedger).toBe(5000);
+    });
+  });
+
+  describe("Error Scenarios", () => {
+    it("should handle simulation error response", async () => {
+      mockRpc.configure({
+        responseType: "error",
+        simulationError: "contract panic: assertion failed",
+      });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("contract panic: assertion failed");
+      expect(result.raw).toBeDefined();
+    });
+
+    it("should handle restore response", async () => {
+      mockRpc.configure({ responseType: "restore" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/restoration/i);
+      expect(result.raw).toBeDefined();
+    });
+
+    it("should handle generic simulation error", async () => {
+      mockRpc.configure({
+        responseType: "error",
+        simulationError: "Transaction simulation failed",
+      });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("Configuration Changes", () => {
+    it("should respect response type changes between calls", async () => {
+      const xdr = createMinimalSorobanTxXdr();
+
+      // First call - success
+      mockRpc.configure({ responseType: "success" });
+      let result = await simulateTransaction(xdr, "testnet");
+      expect(result.success).toBe(true);
+
+      // Second call - error
+      mockRpc.configure({
+        responseType: "error",
+        simulationError: "test error",
+      });
+      result = await simulateTransaction(xdr, "testnet");
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("test error");
+
+      // Third call - restore
+      mockRpc.configure({ responseType: "restore" });
+      result = await simulateTransaction(xdr, "testnet");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/restoration/i);
+    });
+
+    it("should update ledger sequence dynamically", async () => {
+      const xdr = createMinimalSorobanTxXdr();
+
+      mockRpc.configure({ ledgerSequence: 1000 });
+      let result = await simulateTransaction(xdr, "testnet");
+      expect(result.raw?.latestLedger).toBe(1000);
+
+      mockRpc.configure({ ledgerSequence: 2000 });
+      result = await simulateTransaction(xdr, "testnet");
+      expect(result.raw?.latestLedger).toBe(2000);
+    });
+  });
+
+  describe("Network Isolation", () => {
+    it("should not require actual network access", async () => {
+      // This test verifies that the mock server handles requests
+      // without making real network calls
+      const xdr = createMinimalSorobanTxXdr();
+      mockRpc.configure({ responseType: "success" });
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.success).toBe(true);
+      // If this passes, we know the mock server responded
+      expect(result.raw).toBeDefined();
+    });
+
+    it("should handle multiple concurrent simulations", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      // Run multiple simulations concurrently
+      const results = await Promise.all([
+        simulateTransaction(xdr, "testnet"),
+        simulateTransaction(xdr, "testnet"),
+        simulateTransaction(xdr, "testnet"),
+      ]);
+
+      // All should succeed
+      results.forEach((result) => {
+        expect(result.success).toBe(true);
+        expect(result.footprint).toBeDefined();
+      });
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty transaction data gracefully", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      // Should still return a valid result structure
+      expect(result).toHaveProperty("success");
+      expect(result).toHaveProperty("raw");
+    });
+
+    it("should preserve cost information from mock response", async () => {
+      mockRpc.configure({ responseType: "success" });
+      const xdr = createMinimalSorobanTxXdr();
+
+      const result = await simulateTransaction(xdr, "testnet");
+
+      expect(result.cost?.cpuInsns).toBe("100000");
+      expect(result.cost?.memBytes).toBe("100000");
+    });
+  });
+});

--- a/src/tests/mocks/rpcServer.ts
+++ b/src/tests/mocks/rpcServer.ts
@@ -1,0 +1,235 @@
+import * as http from "http";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+/**
+ * Response type for mock RPC server
+ */
+export type MockResponseType = "success" | "error" | "restore";
+
+/**
+ * Configuration for mock RPC responses
+ */
+export interface MockRpcConfig {
+  responseType?: MockResponseType;
+  simulationError?: string;
+  transactionData?: string;
+  ledgerSequence?: number;
+}
+
+/**
+ * Mock RPC Server instance
+ */
+export interface MockRpcServerInstance {
+  port: number;
+  url: string;
+  server: http.Server;
+  configure: (config: MockRpcConfig) => void;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Default mock responses for different scenarios
+ */
+const DEFAULT_RESPONSES = {
+  success: {
+    transactionData: StellarSdk.xdr.TransactionData.fromXDR(
+      Buffer.from(
+        "AAAAAgAAAABmzb2MAAAAAAAAAAEAAAABAAAAAwAAAAA=",
+        "base64",
+      ),
+    ).toXDR("base64"),
+    minResourceFee: "100000",
+    events: [],
+    latestLedger: 1000,
+  },
+  error: {
+    error: "Transaction simulation failed",
+  },
+  restore: {
+    restorePreamble: Buffer.from("restore_preamble").toString("base64"),
+    minResourceFee: "100000",
+  },
+};
+
+/**
+ * Create a lightweight mock Stellar RPC server for testing
+ * Starts on a random port and returns configurable responses
+ *
+ * @returns Promise resolving to MockRpcServerInstance
+ *
+ * @example
+ * ```typescript
+ * const mockRpc = await startMockRpcServer();
+ * mockRpc.configure({ responseType: "success" });
+ * // Use mockRpc.url in your tests
+ * await mockRpc.stop();
+ * ```
+ */
+export async function startMockRpcServer(): Promise<MockRpcServerInstance> {
+  let config: MockRpcConfig = { responseType: "success" };
+
+  const requestHandler = (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): void => {
+    // Only handle POST requests
+    if (req.method !== "POST") {
+      res.writeHead(405, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Method not allowed" }));
+      return;
+    }
+
+    // Collect request body
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on("end", () => {
+      try {
+        const jsonBody = JSON.parse(body);
+        const method = jsonBody.method || "";
+
+        // Route to appropriate handler
+        if (method === "simulateTransaction") {
+          handleSimulateTransaction(res, config);
+        } else if (method === "getLatestLedger") {
+          handleGetLatestLedger(res, config);
+        } else if (method === "getLedgerEntries") {
+          handleGetLedgerEntries(res, config);
+        } else {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: `Unknown method: ${method}` }));
+        }
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid JSON" }));
+      }
+    });
+  };
+
+  const server = http.createServer(requestHandler);
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to get server address"));
+        return;
+      }
+
+      const port = address.port;
+      const url = `http://127.0.0.1:${port}`;
+
+      resolve({
+        port,
+        url,
+        server,
+        configure: (newConfig: MockRpcConfig) => {
+          config = { ...config, ...newConfig };
+        },
+        stop: async () => {
+          return new Promise((stopResolve, stopReject) => {
+            server.close((err) => {
+              if (err) stopReject(err);
+              else stopResolve();
+            });
+          });
+        },
+      });
+    });
+
+    server.on("error", reject);
+  });
+}
+
+/**
+ * Handle simulateTransaction RPC method
+ */
+function handleSimulateTransaction(
+  res: http.ServerResponse,
+  config: MockRpcConfig,
+): void {
+  res.writeHead(200, { "Content-Type": "application/json" });
+
+  const responseType = config.responseType || "success";
+
+  if (responseType === "error") {
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        result: {
+          error: config.simulationError || DEFAULT_RESPONSES.error.error,
+        },
+        id: 1,
+      }),
+    );
+  } else if (responseType === "restore") {
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        result: {
+          restorePreamble: DEFAULT_RESPONSES.restore.restorePreamble,
+          minResourceFee: DEFAULT_RESPONSES.restore.minResourceFee,
+        },
+        id: 1,
+      }),
+    );
+  } else {
+    // success response
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        result: {
+          transactionData:
+            config.transactionData || DEFAULT_RESPONSES.success.transactionData,
+          minResourceFee: DEFAULT_RESPONSES.success.minResourceFee,
+          events: DEFAULT_RESPONSES.success.events,
+          latestLedger: config.ledgerSequence || DEFAULT_RESPONSES.success.latestLedger,
+        },
+        id: 1,
+      }),
+    );
+  }
+}
+
+/**
+ * Handle getLatestLedger RPC method
+ */
+function handleGetLatestLedger(
+  res: http.ServerResponse,
+  config: MockRpcConfig,
+): void {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      result: {
+        sequence: config.ledgerSequence || DEFAULT_RESPONSES.success.latestLedger,
+        protocolVersion: 21,
+        sorobanLedgerSequence: config.ledgerSequence || DEFAULT_RESPONSES.success.latestLedger,
+      },
+      id: 1,
+    }),
+  );
+}
+
+/**
+ * Handle getLedgerEntries RPC method
+ */
+function handleGetLedgerEntries(
+  res: http.ServerResponse,
+  config: MockRpcConfig,
+): void {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      result: {
+        entries: [],
+        latestLedger: config.ledgerSequence || DEFAULT_RESPONSES.success.latestLedger,
+      },
+      id: 1,
+    }),
+  );
+}


### PR DESCRIPTION
closes #48



Description:
Build a lightweight mock RPC server that returns configurable responses, enabling integration tests without network access.

Requirements and context:

Starts on a random port per test suite
Configurable responses: success, error, restore
Supports simulateTransaction endpoint
Cleans up after tests
Suggested execution:
Fork the repo and create a branch
git checkout -b feature/mock-rpc-server

Implement changes:

Create src/tests/mocks/rpcServer.ts
Use http.createServer with configurable handlers
Export start/stop/configure helpers
Test and commit:

Use mock server in at least one integration test
Verify tests pass without network access
Example commit message:
test: add configurable mock Stellar RPC server for testing