### PR TITLE
security: add XDR validation and length limits

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -29,6 +29,23 @@ export async function simulate(
     return next(new AppError(ERROR_MESSAGES.MISSING_XDR, HTTP_STATUS.BAD_REQUEST));
   }
 
+  // Validate XDR is valid base64
+  if (!/^[A-Za-z0-9+/]+=*$/.test(xdr)) {
+    return next(
+      new AppError(
+        "Invalid XDR: must be valid base64",
+        HTTP_STATUS.BAD_REQUEST,
+      ),
+    );
+  }
+
+  // Enforce max XDR length (100kb)
+  if (xdr.length > 100 * 1024) {
+    return next(
+      new AppError("XDR too large: maximum 100kb", HTTP_STATUS.BAD_REQUEST),
+    );
+  }
+
   if (
     network &&
     network !== NETWORKS.MAINNET &&
@@ -38,7 +55,6 @@ export async function simulate(
       new AppError(ERROR_MESSAGES.INVALID_NETWORK, HTTP_STATUS.BAD_REQUEST),
     );
   }
-}
 
   const net: Network = network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
 


### PR DESCRIPTION
Add base64 validation and 100kb size limit for XDR input to prevent malformed or oversized requests