### PR TITLE
feature:Add Redis-backed cache for multi-instance deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,8 @@ SIMULATE_TIMEOUT_MS=30000
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
 
-# Redis Configuration (optional)
-REDIS_HOST=redis
-REDIS_PORT=6379
+# Redis Configuration (optional — enables Redis cache backend when set)
+# REDIS_URL=redis://localhost:6379
 
 # Compression (bytes, default: 1024)
 COMPRESSION_THRESHOLD=1024

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,30 @@ services:
       - TESTNET_SECRET_KEY=${TESTNET_SECRET_KEY}
       - MAINNET_SECRET_KEY=${MAINNET_SECRET_KEY}
       - SIMULATE_TIMEOUT_MS=${SIMULATE_TIMEOUT_MS:-30000}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app_net
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    networks:
+      - app_net
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis_data:
 
 networks:
   app_net:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "compression": "1.8.1",
     "dotenv": "16.3.1",
     "express": "4.18.2",
+    "ioredis": "^5.10.1",
     "prom-client": "15.1.0"
   },
   "devDependencies": {

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -4,6 +4,7 @@ import { Network } from "../config/stellar";
 import { getNetworkStatus } from "../services/networkStatus";
 import metrics from "../middleware/metrics";
 import { AppError } from "../utils/AppError";
+import { getCache } from "../services/cache";
 import {
   NETWORKS,
   DEFAULT_NETWORK,
@@ -121,6 +122,28 @@ export async function validate(
 ): Promise<void> {
   try {
     res.status(HTTP_STATUS.OK).json({ message: "Not implemented" });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : ERROR_MESSAGES.UNEXPECTED_ERROR;
+    next(new AppError(message, HTTP_STATUS.INTERNAL_SERVER_ERROR));
+  }
+}
+
+/**
+ * Handle DELETE /api/cache requests
+ * Flushes all entries from the active cache backend (Redis or in-memory)
+ */
+export async function invalidateCache(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const cache = getCache();
+    await cache.flush();
+    res.status(HTTP_STATUS.OK).json({
+      message: "Cache invalidated",
+      backend: cache.backend,
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : ERROR_MESSAGES.UNEXPECTED_ERROR;
     next(new AppError(message, HTTP_STATUS.INTERNAL_SERVER_ERROR));

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,10 +1,13 @@
 import { Router } from "express";
-import { simulate, footprintDiffController, validate, networkStatus } from "./controllers";
+import {
+  simulate,
+  footprintDiffController,
+  validate,
+  networkStatus,
+  invalidateCache,
+} from "./controllers";
 
 const router = Router();
-
-// Create the simulate controller with the real simulator injected
-const simulate = createSimulateController(simulateTransaction);
 
 // POST /simulate — accepts { xdr, network } and returns footprint + cost
 router.post("/simulate", simulate);
@@ -17,5 +20,8 @@ router.post("/footprint/diff", footprintDiffController);
 
 // POST /validate — accepts { xdr, type } and returns parse result without simulating
 router.post("/validate", validate);
+
+// DELETE /cache — flush all cache entries (Redis or in-memory)
+router.delete("/cache", invalidateCache);
 
 export default router;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,11 @@ export const CACHE_TTL = {
   NETWORK_STATUS_MS: 10000, // 10 seconds
   CONTRACT_EXISTENCE_MS: 30000, // 30 seconds
   RPC_POOL_MS: 300000, // 5 minutes
+  SIMULATION_MS: 60000, // 1 minute (for simulation result caching)
+} as const;
+
+export const CACHE_CONFIG = {
+  MAX_SIZE: 500, // Max entries in LRU in-memory cache
 } as const;
 
 export const ERROR_MESSAGES = {

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -1,0 +1,177 @@
+import { createHash } from "crypto";
+import Redis from "ioredis";
+import { logger } from "../utils/logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export interface CacheService {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+  flush(): Promise<void>;
+  /** Which backend is currently active */
+  readonly backend: "redis" | "memory";
+}
+
+// ---------------------------------------------------------------------------
+// In-memory LRU cache
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_SIZE = 500;
+
+class LruMemoryCache implements CacheService {
+  readonly backend = "memory" as const;
+
+  private readonly store = new Map<string, CacheEntry<unknown>>();
+  private readonly maxSize: number;
+
+  constructor(maxSize = DEFAULT_MAX_SIZE) {
+    this.maxSize = maxSize;
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+
+    // LRU: move to end (most recently used)
+    this.store.delete(key);
+    this.store.set(key, entry);
+
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    // Evict oldest entry when at capacity
+    if (this.store.size >= this.maxSize && !this.store.has(key)) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async flush(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Redis cache adapter
+// ---------------------------------------------------------------------------
+
+class RedisCache implements CacheService {
+  readonly backend = "redis" as const;
+
+  constructor(private readonly client: Redis) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const raw = await this.client.get(key);
+    if (raw === null) return null;
+    return JSON.parse(raw) as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    // PX = millisecond precision TTL
+    await this.client.set(key, JSON.stringify(value), "PX", ttlMs);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+
+  async flush(): Promise<void> {
+    await this.client.flushdb();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory — builds the right backend, falls back to memory on Redis failure
+// ---------------------------------------------------------------------------
+
+let _cache: CacheService | null = null;
+
+export function getCache(): CacheService {
+  if (_cache) return _cache;
+
+  const redisUrl = process.env.REDIS_URL;
+
+  if (redisUrl) {
+    try {
+      const client = new Redis(redisUrl, {
+        // Fail fast on initial connect so we can fall back immediately
+        connectTimeout: 3000,
+        maxRetriesPerRequest: 1,
+        enableOfflineQueue: false,
+        lazyConnect: false,
+      });
+
+      client.on("error", (err: Error) => {
+        logger.warn("Redis error — falling back to in-memory cache", err.message);
+        _cache = new LruMemoryCache();
+      });
+
+      client.on("connect", () => {
+        logger.info("Redis cache connected");
+      });
+
+      client.on("reconnecting", () => {
+        logger.warn("Redis reconnecting…");
+      });
+
+      _cache = new RedisCache(client);
+      logger.info("Cache backend: Redis", { url: redisUrl });
+    } catch (err) {
+      logger.warn("Failed to initialise Redis — falling back to in-memory cache", err);
+      _cache = new LruMemoryCache();
+    }
+  } else {
+    _cache = new LruMemoryCache();
+    logger.info("Cache backend: in-memory LRU (REDIS_URL not set)");
+  }
+
+  return _cache;
+}
+
+/**
+ * Replace the active cache instance.
+ * Exposed for testing and for the fallback swap on Redis errors.
+ */
+export function setCache(instance: CacheService): void {
+  _cache = instance;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a deterministic cache key from arbitrary request data.
+ * Uses SHA-256 so key length is always fixed regardless of input size.
+ */
+export function buildCacheKey(data: Record<string, unknown>): string {
+  const canonical = JSON.stringify(
+    Object.keys(data)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = data[k];
+        return acc;
+      }, {}),
+  );
+  return createHash("sha256").update(canonical).digest("hex");
+}


### PR DESCRIPTION
closes #51


Description:
Extend the caching layer to support Redis as a backend, falling back to in-memory cache if Redis is unavailable.

Requirements and context:

REDIS_URL env var enables Redis cache
Graceful fallback to in-memory if Redis connection fails
Cache invalidation endpoint DELETE /api/cache
Suggested execution:
Fork the repo and create a branch
git checkout -b feature/redis-cache

Implement changes:

Install ioredis
Extend src/services/cache.ts with Redis adapter
Add DELETE /api/cache endpoint
Test and commit:

Test with Redis running via docker-compose
Test fallback by stopping Redis mid-run
Include docker-compose Redis config in PR
Example commit message:
feat: add Redis-backed cache with in-memory fallback

Files:
src/services/cache.ts