### PR TITLE
fix: allow-http config, body size limit, port validation, rpc timeout

### DIFF
--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -1,10 +1,10 @@
 import { Request, Response, NextFunction } from "express";
-import { simulateTransaction } from "@services/simulator";
+import { simulateTransaction, simulateWithTimeout, SimulationTimeoutError } from "@services/simulator";
 import { Network } from "@config/stellar";
 import { getNetworkStatus } from "@services/networkStatus";
 import metrics from "@middleware/metrics";
 import { AppError } from "@utils/AppError";
-import { simulateTransaction } from "../services/simulator";
+import { simulateTransaction, simulateWithTimeout, SimulationTimeoutError } from "../services/simulator";
 import { buildRestoreTransaction } from "../services/restorer";
 import { Network } from "../config/stellar";
 import { getNetworkStatus } from "../services/networkStatus";
@@ -481,7 +481,7 @@ export async function simulate(req: Request, res: Response): Promise<void> {
 
   try {
 <<<<<<< ours
-    const result = await simulateTransaction(xdr, net, res.locals.abortSignal);
+    const result = await simulateWithTimeout(xdr, net, res.locals.abortSignal);
 
 <<<<<<< ours
 <<<<<<< ours
@@ -541,6 +541,10 @@ export async function simulate(req: Request, res: Response): Promise<void> {
     res.status(result.success ? 200 : 422).json(response);
 >>>>>>> theirs
   } catch (err: unknown) {
+    if (err instanceof SimulationTimeoutError) {
+      res.status(504).json({ error: "Simulation timed out" });
+      return;
+    }
     if (
       err instanceof Error &&
       (err as { circuitOpen?: boolean; retryAfter?: number }).circuitOpen
@@ -614,7 +618,7 @@ export async function simulateBatch(
 =======
 
 =======
-    const result = await simulateTransaction(xdr, net, res.locals.abortSignal, ledgerSequence);
+    const result = await simulateWithTimeout(xdr, net, res.locals.abortSignal, ledgerSequence);
     
 >>>>>>> theirs
     // Record simulation metrics

--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -71,7 +71,8 @@ export function getRpcServer(
   }
 
   const { rpcUrl } = getNetworkConfig(network);
-  const server = new StellarSdk.SorobanRpc.Server(rpcUrl, { allowHttp: false });
+  const allowHttp = process.env.ALLOW_HTTP === "true";
+  const server = new StellarSdk.SorobanRpc.Server(rpcUrl, { allowHttp });
   pool.set(network, { server, createdAt: now });
   return server;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,12 @@ import { logger } from "./utils/logger";
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const _rawPort = process.env.PORT || "3000";
+const _parsedPort = parseInt(_rawPort, 10);
+if (!Number.isInteger(_parsedPort) || _parsedPort <= 0 || String(_parsedPort) !== _rawPort.trim()) {
+  throw new Error(`PORT must be a valid number, got: "${_rawPort}"`);
+}
+const PORT = _parsedPort;
 const COMPRESSION_THRESHOLD = parseInt(
   process.env.COMPRESSION_THRESHOLD || "1024",
   10,
@@ -103,7 +108,7 @@ app.use(helmet({
 =======
 >>>>>>> theirs
 app.use(compression({ threshold: COMPRESSION_THRESHOLD }));
-app.use(express.json());
+app.use(express.json({ limit: process.env.BODY_LIMIT || "100kb" }));
 app.use(responseTimeMiddleware);
 app.use(ipFilterMiddleware);
 app.use(requestLogger);

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -1388,3 +1388,36 @@ export async function simulateTransaction(
 >>>>>>> theirs
 =======
 >>>>>>> theirs
+
+export class SimulationTimeoutError extends Error {
+  constructor() {
+    super("Simulation timed out");
+    this.name = "SimulationTimeoutError";
+  }
+}
+
+const DEFAULT_SIMULATE_TIMEOUT_MS = 30000;
+
+export async function simulateWithTimeout(
+  xdr: string,
+  network: Network = "testnet",
+  signal?: AbortSignal,
+  ledgerSequence?: number,
+): Promise<SimulateResult> {
+  const timeoutMs = parseInt(
+    process.env.SIMULATE_TIMEOUT_MS || String(DEFAULT_SIMULATE_TIMEOUT_MS),
+    10,
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new SimulationTimeoutError()), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      simulateTransaction(xdr, network, signal, ledgerSequence),
+      timeoutPromise,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
closes #7 
closes #8 
closes #9 
closes #10 



- feat(config): make allowHttp configurable via ALLOW_HTTP env var (default false)
- fix(index): add 100kb body size limit to express.json, configurable via BODY_LIMIT
- fix(index): validate PORT as positive integer at startup, fail fast with clear message
- fix(simulator): add SIMULATE_TIMEOUT_MS timeout to simulateTransaction, return 504 on expiry