### PR TITLE
fix: lazy config load, sanitize RPC errors, error type discrimination , CORS middleware

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,21 +1,4 @@
-<<<<<<< ours
-<<<<<<< ours
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm format
-pnpm lint
-pnpm tsc --noEmit
-<<<<<<< ours
-<<<<<<< ours
-
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-pnpm format
->>>>>>> theirs
-=======
-pnpm format
->>>>>>> theirs
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -22,125 +22,12 @@
     "load-test": "node scripts/load-test.js"
   },
   "dependencies": {
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
     "@stellar/stellar-sdk": "^15.0.1",
-=======
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-
-    "@stellar/stellar-sdk": "^15.0.1",
-
->>>>>>> theirs
-    "@stellar/stellar-sdk": "^12.0.0",
-
     "compression": "^1.8.1",
+    "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
-    "prom-client": "^15.1.0",
-    "tsconfig-paths": "^4.2.0"
-=======
-=======
->>>>>>> theirs
-=======
-    "prom-client": "^15.1.0",
-    "tsconfig-paths": "^4.2.0"
->>>>>>> theirs
-    "express-rate-limit": "^8.4.0",
-    "prom-client": "^15.1.0"
-
-    "prom-client": "^15.1.0",
-    "tsconfig-paths": "^4.2.0"
-
-  },
-  "devDependencies": {
-    "@types/compression": "^1.8.1",
-    "@types/express": "^5.0.6",
-    "@types/jest": "^30.0.0",
-    "@types/node": "^25.6.0",
-    "@types/supertest": "^6.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.58.2",
-    "@typescript-eslint/parser": "^8.59.0",
-    "eslint": "^10.2.1",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.5",
-    "husky": "^9.1.7",
-    "jest": "^30.3.0",
-    "prettier": "^3.8.3",
-    "solhint": "^6.2.1",
-    "supertest": "^7.0.0",
-    "ts-jest": "^29.4.9",
-    "ts-node": "^10.9.2",
-    "typescript": "^6.0.3",
-    "validate-branch-name": "^1.3.2"
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
->>>>>>> theirs
-=======
-
->>>>>>> theirs
-    "@stellar/stellar-sdk": "12.0.0",
-    "compression": "1.8.1",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-    "ioredis": "^5.10.1",
-    "prom-client": "15.1.0"
-    "dotenv": "^16.3.1",
-    "express": "^4.18.2",
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-
->>>>>>> theirs
     "helmet": "^8.0.0",
-    "prom-client": "^15.1.0"
-
-    "@stellar/stellar-sdk": "12.0.0",
-    "compression": "1.8.1",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-
-    "ioredis": "^5.10.1",
     "prom-client": "^15.1.0",
     "tsconfig-paths": "^4.2.0"
   },
@@ -148,6 +35,7 @@
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@types/compression": "^1.8.1",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
@@ -160,7 +48,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
-    "lint-staged": "16.4.0",
+    "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "solhint": "^6.2.1",
     "supertest": "^7.0.0",
@@ -168,112 +56,10 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "validate-branch-name": "^1.3.2"
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
->>>>>>> theirs
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.{js,jsx,json,md}": [
-      "prettier --write"
-    ]
-
-
-    "@commitlint/cli": "19.0.0",
-    "@commitlint/config-conventional": "19.0.0",
-    "@types/compression": "1.8.1",
-    "@types/express": "4.17.21",
-    "@types/jest": "30.0.0",
-=======
-    "@stellar/stellar-sdk": "12.0.0",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-    "prom-client": "15.1.0"
-  },
-  "devDependencies": {
-    "@types/express": "4.17.21",
->>>>>>> theirs
-=======
-=======
->>>>>>> theirs
-    "@stellar/stellar-sdk": "12.0.0",
-    "compression": "1.8.1",
-    "dotenv": "16.3.1",
-    "express": "4.18.2",
-    "prom-client": "15.1.0"
-  },
-  "devDependencies": {
-    "@types/compression": "1.8.1",
-    "@types/express": "4.17.21",
-<<<<<<< ours
->>>>>>> theirs
-=======
-    "@types/jest": "30.0.0",
->>>>>>> theirs
-    "@types/node": "20.10.0",
-    "@typescript-eslint/eslint-plugin": "8.58.2",
-    "@typescript-eslint/parser": "8.58.2",
-    "eslint": "10.2.1",
-    "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-prettier": "5.5.5",
-    "husky": "9.1.7",
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-    "jest": "30.3.0",
-    "lint-staged": "15.2.0",
-=======
-    "jest": "30.3.0",
->>>>>>> theirs
-    "prettier": "3.8.3",
-    "solhint": "6.2.1",
-    "ts-jest": "29.4.9",
-    "ts-node": "10.9.2",
-    "typescript": "5.3.2",
-    "validate-branch-name": "1.3.2"
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-=======
->>>>>>> theirs
-    "prettier": "3.8.3",
-    "solhint": "6.2.1",
-    "ts-node": "10.9.2",
-    "typescript": "5.3.2",
-    "validate-branch-name": "1.3.2"
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-
-
->>>>>>> theirs
   },
   "validate-branch-name": {
     "pattern": "^(main|develop|live)$|^(feature|fix|refactor|hotfix|release|conflict|chore)/.+$",
     "errorMsg": "Branch name must be: main | develop | live\nOr prefixed with: feature/ | fix/ | refactor/ | hotfix/ | release/ | conflict/ | chore/\nExample: feature/my-new-feature"
-<<<<<<< ours
-<<<<<<< ours
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -283,9 +69,5 @@
     "*.{js,jsx,json,md}": [
       "prettier --write"
     ]
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
   }
 }

--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -45,8 +45,6 @@ export function getNetworkConfig(network: Network = "testnet"): NetworkConfig {
   return config;
 }
 
-const RPC_POOL_TTL_MS = parseInt(process.env.RPC_POOL_TTL_MS || "300000", 10);
-
 interface PoolEntry {
   server: StellarSdk.SorobanRpc.Server;
   createdAt: number;
@@ -63,10 +61,12 @@ const pool = new Map<Network, PoolEntry>();
 export function getRpcServer(
   network: Network = "testnet",
 ): StellarSdk.SorobanRpc.Server {
+  // Read at call time so dotenv.config() in index.ts runs first
+  const rpcPoolTtlMs = parseInt(process.env.RPC_POOL_TTL_MS || "300000", 10);
   const now = Date.now();
   const entry = pool.get(network);
 
-  if (entry && now - entry.createdAt < RPC_POOL_TTL_MS) {
+  if (entry && now - entry.createdAt < rpcPoolTtlMs) {
     return entry.server;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,71 +1,22 @@
+// dotenv must be configured before any other imports that read process.env
+import dotenv from "dotenv";
+dotenv.config();
+
 import express from "express";
 import compression from "compression";
 import helmet from "helmet";
-import dotenv from "dotenv";
-import routes from "@api/routes";
-import { metricsMiddleware, metrics } from "@middleware/metrics";
-import { timeoutMiddleware } from "@middleware/timeout";
-import { ipFilterMiddleware } from "@middleware/ipFilter";
-import { requestLogger } from "@middleware/requestLogger";
-import { bruteForceMiddleware } from "@middleware/bruteForce";
-import { errorHandler } from "@middleware/errorHandler";
+import cors from "cors";
 import routes from "./api/routes";
 import { metricsMiddleware, metrics } from "./middleware/metrics";
 import { timeoutMiddleware } from "./middleware/timeout";
-<<<<<<< ours
 import { ipFilterMiddleware } from "./middleware/ipFilter";
 import { requestLogger } from "./middleware/requestLogger";
-<<<<<<< ours
-<<<<<<< ours
 import { bruteForceMiddleware } from "./middleware/bruteForce";
-<<<<<<< ours
-<<<<<<< ours
 import { contentTypeMiddleware } from "./middleware/contentType";
 import { errorHandler } from "./middleware/errorHandler";
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-import { rpcCircuitBreaker } from "./utils/circuitBreaker";
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-import { logger } from "./utils/logger";
-=======
 import { responseTimeMiddleware } from "./middleware/responseTime";
->>>>>>> theirs
-=======
-import { responseTimeMiddleware } from "./middleware/responseTime";
->>>>>>> theirs
-=======
-import { bruteForceMiddleware } from "./middleware/bruteForce";
->>>>>>> theirs
-=======
 import { rpcCircuitBreaker } from "./utils/circuitBreaker";
->>>>>>> theirs
-=======
-import { rpcCircuitBreaker } from "./utils/circuitBreaker";
->>>>>>> theirs
-=======
 import { logger } from "./utils/logger";
->>>>>>> theirs
-=======
-import { logger } from "./utils/logger";
->>>>>>> theirs
-=======
-import { logger } from "./utils/logger";
->>>>>>> theirs
-=======
-import { logger } from "./utils/logger";
->>>>>>> theirs
-
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -74,11 +25,21 @@ const COMPRESSION_THRESHOLD = parseInt(
   10,
 );
 
-// Middleware
-<<<<<<< ours
-<<<<<<< ours
-=======
->>>>>>> theirs
+// CORS — read allowed origins from CORS_ORIGIN env var (comma-separated list)
+// Defaults to * in development, strict in production
+function buildCorsOptions(): cors.CorsOptions {
+  const origin = process.env.CORS_ORIGIN;
+  if (!origin) {
+    return process.env.NODE_ENV === "production"
+      ? { origin: false }
+      : { origin: "*" };
+  }
+  const allowed = origin.split(",").map((o) => o.trim());
+  return { origin: allowed.length === 1 ? allowed[0] : allowed };
+}
+
+app.use(cors(buildCorsOptions()));
+
 app.use(
   helmet({
     contentSecurityPolicy: {
@@ -89,19 +50,6 @@ app.use(
     },
   }),
 );
-<<<<<<< ours
-=======
-app.use(helmet({
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'none'"],
-      frameAncestors: ["'none'"],
-    },
-  },
-}));
->>>>>>> theirs
-=======
->>>>>>> theirs
 app.use(compression({ threshold: COMPRESSION_THRESHOLD }));
 app.use(express.json());
 app.use(responseTimeMiddleware);
@@ -110,138 +58,31 @@ app.use(requestLogger);
 app.use(metricsMiddleware);
 app.use(timeoutMiddleware);
 app.use(bruteForceMiddleware);
-<<<<<<< ours
 app.use(contentTypeMiddleware);
-=======
->>>>>>> theirs
 
 // Health check endpoint
-<<<<<<< ours
-<<<<<<< ours
-app.get("/health", (req, res) => {
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
+app.get("/health", (_req, res) => {
   const circuit = rpcCircuitBreaker.getState();
   res.status(200).json({
     status: "healthy",
-=======
-=======
->>>>>>> theirs
-app.get("/api/health", (req, res) => {
-  res.status(200).json({ 
-    status: "healthy", 
->>>>>>> theirs
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
     circuitBreaker: circuit,
-<<<<<<< ours
-<<<<<<< ours
-=======
-  res.status(200).json({
-    status: "healthy",
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
->>>>>>> theirs
-=======
-  res.status(200).json({
-    status: "healthy",
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
->>>>>>> theirs
-=======
-=======
-  const circuit = rpcCircuitBreaker.getState();
->>>>>>> theirs
-  res.status(200).json({
-    status: "healthy",
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
-<<<<<<< ours
->>>>>>> theirs
-=======
-  res.status(200).json({
-    status: "healthy",
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
->>>>>>> theirs
-=======
-    circuitBreaker: circuit,
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
   });
 });
 
 // Metrics endpoint
-app.get("/metrics", async (req, res) => {
+app.get("/metrics", async (_req, res) => {
   try {
     res.set("Content-Type", "text/plain");
     res.end(await metrics.getMetrics());
   } catch (error: unknown) {
     res.status(500).end(error instanceof Error ? error.message : String(error));
-<<<<<<< ours
-<<<<<<< ours
   }
 });
 
 // API v1 routes
 app.use("/api/v1", routes);
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
-=======
-=======
->>>>>>> theirs
-
-<<<<<<< ours
-// Backward-compat: redirect /api/* → /api/v1/*
-app.use("/api/:path(*)", (req, res) => {
-  res.redirect(308, `/api/v1/${req.params.path}${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`);
-});
-<<<<<<< ours
->>>>>>> theirs
-
-// Backward-compat: redirect /api/* → /api/v1/*
-app.use("/api/:path(*)", (req, res) => {
-  res.redirect(308, `/api/v1/${req.params.path}${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`);
-});
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
-
-// Backward-compat: redirect /api/* → /api/v1/*
-app.use("/api/*", (req, res, next) => {
-  const path = req.params[0];
-
-  if (path === "v1" || path.startsWith("v1/")) {
-    next();
-    return;
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-  }
-
-  res.redirect(
-    308,
-    `/api/v1/${path}${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`,
-  );
-});
->>>>>>> theirs
 
 // Backward-compat: redirect /api/* → /api/v1/*
 app.use("/api/:path(*)", (req, res) => {
@@ -252,25 +93,10 @@ app.use("/api/:path(*)", (req, res) => {
     `/api/v1/${path}${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`,
   );
 });
-<<<<<<< ours
-=======
-=======
->>>>>>> theirs
-// Only start the server when this file is run directly (not imported in tests)
-if (require.main === module) {
-  app.listen(PORT, () => {
-    console.warn(`stellar-footprint-service running on port ${PORT}`);
-  });
-}
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
 
 // Error handling middleware (must be last)
 app.use(errorHandler);
 
-<<<<<<< ours
 // Only start the server when this file is run directly (not imported in tests)
 if (require.main === module) {
   app.listen(PORT, () => {
@@ -281,39 +107,5 @@ if (require.main === module) {
     });
   });
 }
-=======
-app.listen(PORT, () => {
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-  logger.info("stellar-footprint-service started", {
-    port: PORT,
-    environment: process.env.NODE_ENV || "development",
-  });
-<<<<<<< ours
-<<<<<<< ours
-=======
-  console.warn(`stellar-footprint-service running on port ${PORT}`);
->>>>>>> theirs
-=======
-  console.warn(`stellar-footprint-service running on port ${PORT}`);
->>>>>>> theirs
-=======
-  console.warn(`stellar-footprint-service running on port ${PORT}`);
->>>>>>> theirs
-=======
->>>>>>> theirs
-=======
->>>>>>> theirs
-});
->>>>>>> theirs
-=======
->>>>>>> theirs
 
 export default app;

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -1,5 +1,6 @@
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { Network, getNetworkConfig, getRpcServer } from "@config/stellar";
+import { sanitizeRpcError } from "../utils/rpcErrorSanitizer";
 import {
   parseFootprint,
   extractContracts,
@@ -303,6 +304,8 @@ export interface SimulateResult {
   /** Resource fee calculated from simulation cost and network fee parameters */
   resourceFee?: string;
   error?: string;
+  /** Machine-readable error type discriminator for failed simulations */
+  type?: "simulation_error" | "restoration_required";
   /** Contract ID that was not found (if error is "Contract not found") */
   contractId?: string;
   raw?: StellarSdk.SorobanRpc.Api.SimulateTransactionResponse;
@@ -659,6 +662,8 @@ export interface SimulateResult {
   };
   resourceFee?: string;
   error?: string;
+  /** Machine-readable error type discriminator for failed simulations */
+  type?: "simulation_error" | "restoration_required";
   contractId?: string;
   raw?: StellarSdk.SorobanRpc.Api.SimulateTransactionResponse;
   requiredSigners?: string[];
@@ -877,12 +882,18 @@ export async function simulateTransaction(
 >>>>>>> theirs
 
   if (StellarSdk.SorobanRpc.Api.isSimulationError(response)) {
-    return { success: false, error: response.error, raw: response };
+    return {
+      success: false,
+      type: "simulation_error" as const,
+      error: sanitizeRpcError(response.error),
+      raw: response,
+    };
   }
 
   if (StellarSdk.SorobanRpc.Api.isSimulationRestore(response)) {
     return {
       success: false,
+      type: "restoration_required" as const,
       error: "Transaction requires ledger entry restoration before simulation.",
       raw: response,
     };

--- a/src/utils/rpcErrorSanitizer.ts
+++ b/src/utils/rpcErrorSanitizer.ts
@@ -1,0 +1,33 @@
+import { logger } from "./logger";
+
+/**
+ * Maps known Stellar RPC error patterns to safe user-facing messages.
+ * Logs the raw error internally for debugging.
+ */
+export function sanitizeRpcError(raw: string): string {
+  logger.debug("RPC simulation error (raw)", { rawError: raw });
+
+  if (/contract.*not.*found|no such contract/i.test(raw)) {
+    return "Contract not found on the specified network.";
+  }
+  if (/invalid xdr|failed to decode/i.test(raw)) {
+    return "Invalid transaction XDR provided.";
+  }
+  if (/insufficient.*balance|account.*not.*found/i.test(raw)) {
+    return "Source account not found or has insufficient balance.";
+  }
+  if (/exceeded.*instructions|cpu.*limit/i.test(raw)) {
+    return "Transaction exceeded CPU instruction limit.";
+  }
+  if (/exceeded.*memory|memory.*limit/i.test(raw)) {
+    return "Transaction exceeded memory limit.";
+  }
+  if (/host.*error|wasm.*trap/i.test(raw)) {
+    return "Contract execution failed during simulation.";
+  }
+  if (/network.*timeout|connection.*refused|econnrefused/i.test(raw)) {
+    return "RPC network error. Please try again.";
+  }
+
+  return "Simulation failed. Please check your transaction and try again.";
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,19 +10,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-<<<<<<< ours
-    "types": ["jest", "node"]
-=======
-=======
->>>>>>> theirs
     "ignoreDeprecations": "6.0",
     "baseUrl": "./src",
     "paths": {
@@ -31,33 +18,8 @@
       "@config/*": ["config/*"],
       "@middleware/*": ["middleware/*"],
       "@utils/*": ["utils/*"]
-    }
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
-    "types": ["node"]
-=======
+    },
     "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
-=======
-    "types": ["node", "jest"]
->>>>>>> theirs
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]


### PR DESCRIPTION
closes #11 
closes #12 
closes #13 
closes #14 

- fix/config-load-order: move RPC_POOL_TTL_MS read inside getRpcServer() for full lazy eval; ensure dotenv.config() runs before all other imports in index.ts
- fix/sanitize-rpc-errors: add rpcErrorSanitizer utility mapping known RPC error patterns to safe messages; log raw error at debug level
- fix/error-type-discrimination: add type field (simulation_error | restoration_required) to SimulateResult for machine-readable error distinction
- fix/add-cors: install cors package; configure via CORS_ORIGIN env var (comma-separated origins); default * in dev, deny-all in prod