### PR TITLE
Refactor/network type guard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig helps maintain consistent coding styles across editors and IDEs
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/api/controllers.ts
+++ b/src/api/controllers.ts
@@ -1,12 +1,13 @@
 import { Request, Response, NextFunction } from "express";
 import { simulateTransaction } from "@services/simulator";
 import { Network } from "@config/stellar";
+import { isValidNetwork } from "@config/stellar";
 import { getNetworkStatus } from "@services/networkStatus";
 import metrics from "@middleware/metrics";
 import { AppError } from "@utils/AppError";
 import { simulateTransaction } from "../services/simulator";
 import { buildRestoreTransaction } from "../services/restorer";
-import { Network } from "../config/stellar";
+import { Network, isValidNetwork } from "../config/stellar";
 import { getNetworkStatus } from "../services/networkStatus";
 import { estimateFee } from "../services/feeEstimator";
 import metrics from "../middleware/metrics";
@@ -398,7 +399,7 @@ export async function simulate(req: Request, res: Response): Promise<void> {
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 <<<<<<< ours
 <<<<<<< ours
 <<<<<<< ours
@@ -436,7 +437,7 @@ export async function simulate(req: Request, res: Response): Promise<void> {
 =======
 >>>>>>> theirs
 
-  const net: Network = network === "mainnet" ? "mainnet" : "testnet";
+  const net: Network = isValidNetwork(network) ? network : "testnet";
 >>>>>>> theirs
 =======
 >>>>>>> theirs
@@ -625,7 +626,7 @@ export async function simulateBatch(
 >>>>>>> theirs
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   metrics.incrementActiveSimulations();
 
@@ -769,7 +770,7 @@ export async function simulateBatch(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   metrics.incrementActiveSimulations();
 
@@ -901,7 +902,7 @@ export async function simulateBatch(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   metrics.incrementActiveSimulations();
 
@@ -1005,7 +1006,7 @@ export async function simulateBatch(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   metrics.incrementActiveSimulations();
 
@@ -1145,7 +1146,7 @@ export async function simulateAsync(
     );
   }
 
-  const net: Network = network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+  const net: Network = isValidNetwork(network) ? network : DEFAULT_NETWORK;
   const jobId = createJob(webhookUrl);
 
   res.status(HTTP_STATUS.ACCEPTED).json({ jobId });
@@ -1192,7 +1193,7 @@ export async function simulateAsync(
     );
   }
 
-  const net: Network = network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+  const net: Network = isValidNetwork(network) ? network : DEFAULT_NETWORK;
   const jobId = createJob(webhookUrl);
 
   res.status(HTTP_STATUS.ACCEPTED).json({ jobId });
@@ -1323,7 +1324,7 @@ export async function restore(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   try {
     const result = await buildRestoreTransaction(xdr, net);
@@ -1448,7 +1449,7 @@ export async function estimateFeeController(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   try {
     const result = await estimateFee(cpuInsns, memBytes, net);
@@ -1641,7 +1642,7 @@ export async function estimateFeeController(
   }
 
   const net: Network =
-    network === NETWORKS.MAINNET ? NETWORKS.MAINNET : DEFAULT_NETWORK;
+    isValidNetwork(network) ? network : DEFAULT_NETWORK;
 
   try {
     const result = await estimateFee(cpuInsns, memBytes, net);
@@ -1694,7 +1695,7 @@ export async function restore(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const net: Network = network === "mainnet" ? "mainnet" : "testnet";
+  const net: Network = isValidNetwork(network) ? network : "testnet";
 
   try {
     const result = await buildRestoreTransaction(xdr, net);
@@ -1721,7 +1722,7 @@ export async function restore(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const net: Network = network === "mainnet" ? "mainnet" : "testnet";
+  const net: Network = isValidNetwork(network) ? network : "testnet";
 
   try {
     const result = await buildRestoreTransaction(xdr, net);

--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -4,6 +4,15 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 export type Network = "mainnet" | "testnet";
 
 /**
+ * Type guard that checks whether a value is a valid Network.
+ * Returns true only for "testnet" and "mainnet".
+ * @param value - The value to check
+ */
+export function isValidNetwork(value: unknown): value is Network {
+  return value === "testnet" || value === "mainnet";
+}
+
+/**
  * Configuration for a Stellar network
  * @property rpcUrl - The RPC endpoint URL for the network
  * @property networkPassphrase - The network passphrase for transaction signing

--- a/src/config/tests/stellar.test.ts
+++ b/src/config/tests/stellar.test.ts
@@ -1,3 +1,5 @@
+import { isValidNetwork } from "../stellar";
+
 jest.mock("@stellar/stellar-sdk", () => ({
   Networks: {
     TESTNET: "Test SDF Network ; September 2015",
@@ -103,5 +105,35 @@ describe("getRpcServer", () => {
   });
   it("defaults to testnet", () => {
     expect(getRpcServer()).toBe(getRpcServer("testnet"));
+  });
+});
+
+describe("isValidNetwork", () => {
+  it("returns true for 'testnet'", () => {
+    expect(isValidNetwork("testnet")).toBe(true);
+  });
+
+  it("returns true for 'mainnet'", () => {
+    expect(isValidNetwork("mainnet")).toBe(true);
+  });
+
+  it("returns false for an unknown string", () => {
+    expect(isValidNetwork("devnet")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isValidNetwork("")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isValidNetwork(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isValidNetwork(undefined)).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isValidNetwork(42)).toBe(false);
   });
 });


### PR DESCRIPTION
This PR introduces a type guard utility to validate and narrow unknown network values into a strongly-typed Network type. The goal is to improve runtime safety, prevent invalid network usage, and enhance TypeScript type inference across the codebase.closes #70 