### PR TITLE
feat: add exponential backoff retry for transient RPC failures

### DIFF
--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -19,6 +19,7 @@ import {
   TtlInfo,
 } from "../types";
 import { rpcCircuitBreaker } from "../utils/circuitBreaker";
+import { withRetry } from "../utils/retry";
 import { sanitizeRpcError } from "../utils/rpcErrorSanitizer";
 
 // Cache for contract existence checks (contractIdString -> { exists: boolean, timestamp: number })
@@ -389,12 +390,16 @@ export async function simulateTransaction(
 
   let response;
   try {
-    response = await rpcCircuitBreaker.call(() =>
-      server.simulateTransaction(
-        tx as StellarSdk.Transaction,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        simOptions as any,
-      ),
+    response = await withRetry(
+      () =>
+        rpcCircuitBreaker.call(() =>
+          server.simulateTransaction(
+            tx as StellarSdk.Transaction,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            simOptions as any,
+          ),
+        ),
+      `simulateTransaction:${network}`,
     );
   } catch (err) {
     metrics.recordRpcError(network, "simulate_transaction_failure");

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,0 +1,93 @@
+import { withRetry, isTransientError } from "../retry";
+
+// Mock the logger to suppress output during tests
+jest.mock("../logger", () => ({
+  logger: { warn: jest.fn(), debug: jest.fn() },
+}));
+
+// Speed up tests by mocking setTimeout
+jest.useFakeTimers();
+
+describe("isTransientError", () => {
+  it("returns true for ECONNRESET", () => {
+    const err = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it("returns true for ETIMEDOUT", () => {
+    const err = Object.assign(new Error("connect ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it("returns true for network timeout message", () => {
+    expect(isTransientError(new Error("network timeout occurred"))).toBe(true);
+  });
+
+  it("returns false for simulation errors", () => {
+    expect(
+      isTransientError(new Error("simulation error: contract failed")),
+    ).toBe(false);
+  });
+
+  it("returns false for invalid XDR", () => {
+    expect(isTransientError(new Error("invalid xdr provided"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isTransientError("string error")).toBe(false);
+    expect(isTransientError(null)).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  it("returns result immediately on success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    const promise = withRetry(fn, "test", 3);
+    await jest.runAllTimersAsync();
+    await expect(promise).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient error and succeeds on third attempt", async () => {
+    const transientErr = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(transientErr)
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValue("success");
+
+    const promise = withRetry(fn, "test", 3);
+    await jest.runAllTimersAsync();
+    await expect(promise).resolves.toBe("success");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on simulation errors", async () => {
+    const simErr = new Error("simulation error: wasm trap");
+    const fn = jest.fn().mockRejectedValue(simErr);
+
+    await expect(withRetry(fn, "test", 3)).rejects.toThrow(
+      "simulation error: wasm trap",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("exhausts retries and throws last error", async () => {
+    const transientErr = Object.assign(new Error("connect ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const fn = jest.fn().mockRejectedValue(transientErr);
+
+    // Run promise and advance timers concurrently
+    const promise = withRetry(fn, "test", 3);
+    await jest.runAllTimersAsync();
+    await expect(promise).rejects.toThrow("connect ETIMEDOUT");
+    expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
+  });
+});

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,101 @@
+import { logger } from "./logger";
+
+/** Error codes considered transient network failures — safe to retry */
+const RETRYABLE_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ENETUNREACH",
+]);
+
+/** Patterns in error messages that indicate a transient network issue */
+const RETRYABLE_MESSAGE_PATTERNS = [
+  /network.*timeout/i,
+  /connection.*reset/i,
+  /connection.*refused/i,
+  /socket.*hang.*up/i,
+  /econnreset/i,
+  /etimedout/i,
+];
+
+/** Patterns that indicate simulation/validation errors — never retry these */
+const NON_RETRYABLE_MESSAGE_PATTERNS = [
+  /simulation.*error/i,
+  /invalid.*xdr/i,
+  /contract.*not.*found/i,
+  /insufficient.*balance/i,
+  /exceeded.*instructions/i,
+  /exceeded.*memory/i,
+  /host.*error/i,
+  /wasm.*trap/i,
+  /validation/i,
+];
+
+export function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  const msg = err.message ?? "";
+  const code = (err as NodeJS.ErrnoException).code ?? "";
+
+  // Never retry simulation/validation errors
+  if (NON_RETRYABLE_MESSAGE_PATTERNS.some((p) => p.test(msg))) return false;
+
+  // Retry on known error codes
+  if (RETRYABLE_CODES.has(code)) return true;
+
+  // Retry on known transient message patterns
+  return RETRYABLE_MESSAGE_PATTERNS.some((p) => p.test(msg));
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const BASE_DELAY_MS = 100;
+
+const parsedMaxRetries = parseInt(
+  process.env.RPC_MAX_RETRIES ?? String(DEFAULT_MAX_RETRIES),
+  10,
+);
+export const RPC_MAX_RETRIES = Number.isFinite(parsedMaxRetries)
+  ? parsedMaxRetries
+  : DEFAULT_MAX_RETRIES;
+
+/**
+ * Executes `fn` with exponential backoff retry for transient RPC errors.
+ * Delays: 100ms, 200ms, 400ms (doubles each attempt).
+ * Never retries simulation or validation errors.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  context = "rpc",
+  maxRetries = RPC_MAX_RETRIES,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+
+      if (attempt >= maxRetries || !isTransientError(err)) {
+        throw err;
+      }
+
+      const delayMs = BASE_DELAY_MS * Math.pow(2, attempt);
+      logger.warn(
+        {
+          context,
+          attempt: attempt + 1,
+          maxRetries,
+          delayMs,
+          error: (err as Error).message,
+        },
+        `Transient RPC error on attempt ${attempt + 1}/${maxRetries}, retrying in ${delayMs}ms`,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
closes #50 