### PR TITLE
fix: resolve retry test failure with Jest 30 fake timers

### DIFF
--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -84,10 +84,13 @@ describe("withRetry", () => {
     });
     const fn = jest.fn().mockRejectedValue(transientErr);
 
-    // Run promise and advance timers concurrently
-    const promise = withRetry(fn, "test", 3);
-    await jest.runAllTimersAsync();
-    await expect(promise).rejects.toThrow("connect ETIMEDOUT");
+    // Attach rejection handler immediately to avoid PromiseRejectionHandledWarning,
+    // then advance fake timers concurrently so the retry loop can complete.
+    const [result] = await Promise.all([
+      expect(withRetry(fn, "test", 3)).rejects.toThrow("connect ETIMEDOUT"),
+      jest.runAllTimersAsync(),
+    ]);
+    void result;
     expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
   });
 });


### PR DESCRIPTION
Fixes the failing CI test in `retry.test.ts`.\n\nThe `exhausts retries and throws last error` test was creating a promise before attaching a rejection handler, causing a `PromiseRejectionHandledWarning` that Jest 30 treats as a test failure.\n\nFix: wrap both the assertion and `runAllTimersAsync` in `Promise.all` so the rejection handler is attached immediately.