### PR TITLE
infra: add Nginx rate limiting, Redis TLS, PM2 cluster mode, and Docker publish workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
 
 # Redis Configuration (optional — enables Redis cache backend when set)
-# REDIS_URL=redis://localhost:6379
+# REDIS_URL=rediss://localhost:6379
 
 # Compression (bytes, default: 1024)
 COMPRESSION_THRESHOLD=1024

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🚀 Stellar Footprint Service
 
 [![CI](https://github.com/josunday002/Stellar-Footprint-Service/actions/workflows/ci.yml/badge.svg)](https://github.com/josunday002/Stellar-Footprint-Service/actions/workflows/ci.yml)
+[![Docker Publish](https://github.com/Dafuriousis/Stellar-Footprint-Service/actions/workflows/release.yml/badge.svg)](https://github.com/Dafuriousis/Stellar-Footprint-Service/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/josunday002/Stellar-Footprint-Service/branch/main/graph/badge.svg)](https://codecov.io/gh/josunday002/Stellar-Footprint-Service)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       - MAINNET_RPC_URL=${MAINNET_RPC_URL}
       - TESTNET_SECRET_KEY=${TESTNET_SECRET_KEY}
       - MAINNET_SECRET_KEY=${MAINNET_SECRET_KEY}
+      - REDIS_URL=${REDIS_URL:-rediss://redis:6379}
     networks:
       - monitoring
     labels:
@@ -68,10 +69,16 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+      - ./docker/redis/certs:/etc/redis/certs:ro
     networks:
       - monitoring
     restart: unless-stopped
-    command: redis-server --appendonly yes
+    command: >
+      redis-server --appendonly yes
+        --tls-port 6379 --port 0
+        --tls-cert-file /etc/redis/certs/redis.crt
+        --tls-key-file /etc/redis/certs/redis.key
+        --tls-ca-cert-file /etc/redis/certs/ca.crt
 
 volumes:
   prometheus_data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -378,6 +378,36 @@ If you want to serve on port 80/443 with TLS:
    }
    ```
 
+3. To protect the `/api/v1/simulate` endpoint from abusive request bursts, add a rate limit rule in your Nginx config:
+
+   ```nginx
+   http {
+     limit_req_zone $binary_remote_addr zone=simulate_req:10m rate=10r/s;
+   }
+
+   server {
+     # ...
+     error_page 429 = @too_many_requests;
+
+     location = /api/v1/simulate {
+       limit_req zone=simulate_req burst=10 nodelay;
+       proxy_pass http://localhost:3000;
+       proxy_set_header Host $host;
+       proxy_set_header X-Real-IP $remote_addr;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+     }
+
+     location @too_many_requests {
+       internal;
+       add_header Content-Type application/json;
+       return 429 '{"error":"Too many requests"}';
+     }
+   }
+   ```
+
+   This ensures the service returns `429` with a JSON error body when rate limiting is exceeded.
+
 3. Enable the site and obtain a TLS certificate:
 
    ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -294,6 +294,9 @@ TESTNET_SECRET_KEY=<your_testnet_secret_key>
 MAINNET_SECRET_KEY=<your_mainnet_secret_key>
 LOG_LEVEL=info
 SIMULATE_TIMEOUT_MS=30000
+# Use TLS for Redis in production when available.
+# For a managed Redis instance, use a rediss:// URL.
+# REDIS_URL=rediss://redis:6379
 ```
 
 #### 6. Create the logs directory

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -311,6 +311,8 @@ mkdir -p logs
 pm2 start ecosystem.config.js --env production
 ```
 
+> The `ecosystem.config.js` file is configured with `instances: "max"` and `exec_mode: "cluster"` so PM2 will distribute worker processes across available CPU cores. The application also handles `SIGTERM`/`SIGINT` gracefully, which allows clustered workers to shut down cleanly.
+
 #### 8. Save PM2 process list and enable startup on reboot
 
 ```bash

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       name: "stellar-footprint-service",
       script: "dist/index.js",
+      // Use PM2 cluster mode to utilise all available CPU cores.
       instances: "max",
       exec_mode: "cluster",
       max_restarts: 10,

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,8 @@
 events {}
 
 http {
+  limit_req_zone $binary_remote_addr zone=simulate_req:10m rate=10r/s;
+
   upstream app {
     server app:3000;
   }
@@ -16,6 +18,23 @@ http {
     ssl_certificate     /etc/nginx/certs/cert.pem;
     ssl_certificate_key /etc/nginx/certs/key.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
+
+    error_page 429 = @too_many_requests;
+
+    location = /api/v1/simulate {
+      limit_req zone=simulate_req burst=10 nodelay;
+      proxy_pass         http://app;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location @too_many_requests {
+      internal;
+      add_header Content-Type application/json;
+      return 429 '{"error":"Too many requests"}';
+    }
 
     location / {
       proxy_pass         http://app;


### PR DESCRIPTION
This PR contains four infrastructure updates:

1. Add Nginx rate limiting for /api/v1/simulate with a 429 JSON response.
2. Configure Redis TLS in docker-compose.prod.yml and update REDIS_URL usage.
3. Document PM2 cluster mode and graceful shutdown support.
4. Update the release workflow to publish the Docker image to GHCR on GitHub release published events and add a README badge.

Each fix was committed on its own branch and combined into this single PR with four commits.

closes #404 
closes #403 
closes #401 
closes #399 