### PR TITLE
fix: resolve issues #405, #406, #408, #410

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: OWASP Dependency-Check
+name: Security
 
 on:
   push:
@@ -29,3 +29,26 @@ jobs:
         with:
           name: dependency-check-report
           path: reports/dependency-check-report.html
+
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          source-root: src
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stellar-footprint-service
+  labels:
+    app: stellar-footprint-service
+spec:
+  podSelector:
+    matchLabels:
+      app: stellar-footprint-service
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow inbound traffic on port 3000 from the ingress controller only
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # Allow egress to Redis (default port 6379) within the cluster
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+
+    # Allow egress to Stellar RPC endpoints (HTTPS)
+    - ports:
+        - protocol: TCP
+          port: 443

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,11 +10,18 @@ export const RPC_URLS = {
   TESTNET: "https://soroban-testnet.stellar.org",
 } as const;
 
+/**
+ * Cache TTL values in milliseconds for various caching layers.
+ * - NETWORK_STATUS_MS: How long to cache network status responses (10 s)
+ * - CONTRACT_EXISTENCE_MS: How long to cache contract existence lookups (30 s)
+ * - RPC_POOL_MS: How long an RPC server connection is reused before recreation (5 min)
+ * - SIMULATION_MS: How long to cache simulation results (1 min)
+ */
 export const CACHE_TTL = {
-  NETWORK_STATUS_MS: 10000, // 10 seconds
-  CONTRACT_EXISTENCE_MS: 30000, // 30 seconds
-  RPC_POOL_MS: 300000, // 5 minutes
-  SIMULATION_MS: 60000, // 1 minute (for simulation result caching)
+  NETWORK_STATUS_MS: 10000,
+  CONTRACT_EXISTENCE_MS: 30000,
+  RPC_POOL_MS: 300000,
+  SIMULATION_MS: 60000,
 } as const;
 
 /** Simulation result LRU cache — configurable via env vars */

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -21,13 +21,13 @@ import {
 import { rpcCircuitBreaker } from "../utils/circuitBreaker";
 import { withRetry } from "../utils/retry";
 import { sanitizeRpcError } from "../utils/rpcErrorSanitizer";
+import { CACHE_TTL } from "../constants";
 
 // Cache for contract existence checks (contractIdString -> { exists: boolean, timestamp: number })
 const contractExistenceCache = new Map<
   string,
   { exists: boolean; timestamp: number }
 >();
-const CONTRACT_EXISTENCE_CACHE_TTL = 30 * 1000; // 30 seconds
 
 function extractRequiredSigners(
   auth: StellarSdk.xdr.SorobanAuthorizationEntry[],
@@ -62,7 +62,7 @@ async function _checkContractExists(
 ): Promise<boolean> {
   const now = Date.now();
   const cached = contractExistenceCache.get(contractIdString);
-  if (cached && now - cached.timestamp < CONTRACT_EXISTENCE_CACHE_TTL) {
+  if (cached && now - cached.timestamp < CACHE_TTL.CONTRACT_EXISTENCE_MS) {
     // Record cache hit
     metrics.recordCacheHit("contract_existence");
     return cached.exists;

--- a/src/services/simulator.ts
+++ b/src/services/simulator.ts
@@ -39,8 +39,10 @@ function extractRequiredSigners(
       if (credentials.switch().name === "sorobanCredentialsAddress") {
         const address = credentials.address();
 
+        const credAddress =
+          address as StellarSdk.xdr.SorobanAddressCredentials;
         const accountId = StellarSdk.StrKey.encodeEd25519PublicKey(
-          (address as any).accountId().value(), // eslint-disable-line @typescript-eslint/no-explicit-any
+          credAddress.address().accountId().ed25519(),
         );
         signers.add(accountId);
       }
@@ -221,8 +223,7 @@ function _extractEvents(
     (response.events as unknown as StellarSdk.xdr.DiagnosticEvent[]) ?? [];
 
   return events.map((event: unknown) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const e = event as any;
+    const e = event as { type?: () => { name?: string }; contractId?: () => Buffer };
     return {
       type: e.type?.()?.name || "unknown",
       contractId: e.contractId?.()?.toString("hex") || "",
@@ -304,8 +305,10 @@ async function _processSimulationResult(
       ? await detectTokenContract(contracts[0], server)
       : "unknown";
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const auth = (transactionData as any)?.auth?.() ?? [];
+  // SorobanTransactionData.build() returns xdr.SorobanTransactionData which
+  // exposes auth() at the XDR level; use unknown cast to avoid any.
+  const builtData = transactionData as unknown as { auth?: () => StellarSdk.xdr.SorobanAuthorizationEntry[] };
+  const auth = builtData.auth?.() ?? [];
   const { requiredSigners, threshold } = extractRequiredSigners(auth);
 
   const footprintStats = calculateFootprintStats(
@@ -383,7 +386,12 @@ export async function simulateTransaction(
     };
   }
 
-  const simOptions: Record<string, unknown> = { signal, includeEvents: true };
+  interface SimulateOptions {
+    signal?: AbortSignal;
+    includeEvents?: boolean;
+    ledger?: number;
+  }
+  const simOptions: SimulateOptions = { signal, includeEvents: true };
   if (ledgerSequence !== undefined) {
     simOptions.ledger = ledgerSequence;
   }
@@ -395,8 +403,7 @@ export async function simulateTransaction(
         rpcCircuitBreaker.call(() =>
           server.simulateTransaction(
             tx as StellarSdk.Transaction,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            simOptions as any,
+            simOptions,
           ),
         ),
       `simulateTransaction:${network}`,
@@ -475,8 +482,8 @@ export async function simulateTransaction(
     const ttl = await fetchTtlInfo(server, allXdrEntries, network);
 
     // Extract required signers from auth entries
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const auth = (result.transactionData?.build() as any)?.auth?.() ?? [];
+    const builtTxData = result.transactionData?.build() as unknown as { auth?: () => StellarSdk.xdr.SorobanAuthorizationEntry[] };
+    const auth = builtTxData?.auth?.() ?? [];
     const { requiredSigners, threshold } = extractRequiredSigners(auth);
 
     // Detect SEP-41 token contract type for the first invoked contract
@@ -497,18 +504,15 @@ export async function simulateTransaction(
       optimized: optimizationResult.optimized,
       rawFootprint,
       cost: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        cpuInsns: (response as any).cost?.cpuInsns ?? "0",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        memBytes: (response as any).cost?.memBytes ?? "0",
+        cpuInsns: response.cost?.cpuInsns ?? "0",
+        memBytes: response.cost?.memBytes ?? "0",
       },
       requiredSigners,
       threshold,
       raw: response,
       diagnosticEvents:
         response.events
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ?.filter((e) => (e as any).type?.()?.name === "diagnostic")
+          ?.filter((e) => (e as unknown as { type?: () => { name?: string } }).type?.()?.name === "diagnostic")
           .map((e) => e.toXDR("base64")) || [],
     };
   } else {
@@ -556,8 +560,8 @@ export async function simulateTransaction(
 
       const ttl = await fetchTtlInfo(server, allXdrEntries, network);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const auth = (result.transactionData?.build() as any)?.auth?.() ?? [];
+      const builtOpData = result.transactionData?.build() as unknown as { auth?: () => StellarSdk.xdr.SorobanAuthorizationEntry[] };
+      const auth = builtOpData?.auth?.() ?? [];
       const { requiredSigners, threshold } = extractRequiredSigners(auth);
 
       const opContractType =
@@ -600,19 +604,11 @@ export async function simulateTransaction(
     // Dedup
     const dedupReadOnly = allReadOnly.filter(
       (item, index, arr) =>
-        arr.findIndex(
-          (i) =>
-            i.contractId === item.contractId &&
-            (i as any).key === (item as any).key, // eslint-disable-line @typescript-eslint/no-explicit-any
-        ) === index,
+        arr.findIndex((i) => i.xdr === item.xdr) === index,
     );
     const dedupReadWrite = allReadWrite.filter(
       (item, index, arr) =>
-        arr.findIndex(
-          (i) =>
-            i.contractId === item.contractId &&
-            (i as any).key === (item as any).key, // eslint-disable-line @typescript-eslint/no-explicit-any
-        ) === index,
+        arr.findIndex((i) => i.xdr === item.xdr) === index,
     );
     const dedupContracts = [...new Set(allContracts)];
     const dedupRawReadOnly = [...new Set(allRawReadOnly)];
@@ -640,8 +636,7 @@ export async function simulateTransaction(
       raw: response,
       diagnosticEvents:
         response.events
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ?.filter((e) => (e as any).type?.()?.name === "diagnostic")
+          ?.filter((e) => (e as unknown as { type?: () => { name?: string } }).type?.()?.name === "diagnostic")
           .map((e) => e.toXDR("base64")) || [],
     };
   }


### PR DESCRIPTION
## Summary

Resolves 4 issues in a single PR with one commit per issue.

### #408 — Replace `any` type casts in simulator.ts
- Replaced all `as any` casts with proper typed alternatives (`unknown` + typed interfaces, `SorobanAddressCredentials`, `SimulateOptions`)
- Removed all `eslint-disable @typescript-eslint/no-explicit-any` comments
- Used `xdr` field for `FootprintEntry` deduplication instead of non-existent `.key`

### #410 — Move inline constants from simulator.ts to constants.ts
- Removed `CONTRACT_EXISTENCE_CACHE_TTL = 30 * 1000` inline constant
- Imported and used `CACHE_TTL.CONTRACT_EXISTENCE_MS` from `src/constants.ts`
- Added JSDoc to `CACHE_TTL` explaining each entry

### #405 — Add CodeQL static analysis to security workflow
- Added `codeql` job to `.github/workflows/security.yml`
- Scans JavaScript/TypeScript with `source-root: src`
- Runs on push to main, PRs, and weekly (same triggers as OWASP job)

### #406 — Add Kubernetes NetworkPolicy to restrict traffic
- Created `k8s/network-policy.yaml`
- Ingress: port 3000 from ingress-nginx only
- Egress: Redis (6379), Stellar RPC (443/HTTPS), DNS (53)
- All other traffic denied by default