### PR TITLE
docs: add caching guide, batch examples, k8s guide, update security p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,10 @@ export default router;
 
 For a beginner-friendly guide explaining what Soroban footprints are, why they are required, and how this service simplifies the process, see [Understanding Soroban Footprints](./docs/guides/understanding-footprints.md).
 
+## 🗄️ Caching Guide
+
+For details on the Redis vs in-memory dual-backend strategy, TTL configuration, cache key structure, and when to use `DELETE /cache`, see [docs/guides/caching.md](./docs/guides/caching.md).
+
 ## 🧩 Integration Guide
 
 ### Step 1: Build Transaction
@@ -944,6 +948,7 @@ Step-by-step guides for deploying to common platforms:
 | Render         | [docs/deployment.md#2-render](./docs/deployment.md#2-render)                       |
 | Fly.io         | [docs/deployment.md#3-flyio](./docs/deployment.md#3-flyio)                         |
 | Bare VPS + PM2 | [docs/deployment.md#4-bare-vps-with-pm2](./docs/deployment.md#4-bare-vps-with-pm2) |
+| Kubernetes     | [docs/guides/kubernetes.md](./docs/guides/kubernetes.md)                           |
 
 See the full [Deployment Guide](./docs/deployment.md) for environment variable reference and health check configuration.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,10 @@
 
 **Please do not open a public GitHub issue for security vulnerabilities.**
 
-To report a vulnerability, email us privately at:
+Report vulnerabilities privately using one of these channels:
 
-**jeremiahniffypeter@gmail.com**
+- **Email:** [jeremiahniffypeter@gmail.com](mailto:jeremiahniffypeter@gmail.com)
+- **GitHub Security Advisories:** [Report a vulnerability](https://github.com/Dafuriousis/Stellar-Footprint-Service/security/advisories/new)
 
 Include as much detail as possible:
 
@@ -15,15 +16,13 @@ Include as much detail as possible:
 - Affected versions or components
 - Any suggested mitigations (optional)
 
-We will acknowledge your report within **48 hours** and aim to provide a resolution timeline within **7 days**.
-
 ## Disclosure Timeline
 
 | Stage | Target timeframe |
 |---|---|
-| Acknowledgement | Within 48 hours of report |
-| Initial assessment | Within 7 days |
-| Fix developed & reviewed | Within 30 days (critical issues prioritised) |
+| Acknowledgement | Within **48 hours** of report |
+| Initial assessment | Within **7 days** |
+| Fix developed & reviewed | Within **30 days** (critical issues prioritised) |
 | Public disclosure | After fix is released, coordinated with reporter |
 
 We follow a **coordinated disclosure** model. We ask that you give us a reasonable window to address the issue before any public disclosure.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,6 +11,7 @@ Step-by-step deployment instructions for **Stellar Footprint Service** across co
 - [Render](#2-render)
 - [Fly.io](#3-flyio)
 - [Bare VPS with PM2](#4-bare-vps-with-pm2)
+- [Kubernetes](#5-kubernetes)
 
 ---
 
@@ -455,3 +456,11 @@ curl -X POST https://<your-host>/api/v1/simulate \
 ```
 
 A `200` from `/health` and a `400` (missing XDR) or `422` from `/api/v1/simulate` both confirm the service is live and routing correctly.
+
+---
+
+## 5. Kubernetes
+
+For deploying to a Kubernetes cluster using the manifests in `k8s/`, see the full [Kubernetes Deployment Guide](./guides/kubernetes.md).
+
+It covers prerequisites, applying manifests, configuring secrets, HPA tuning, and health check configuration.

--- a/docs/examples/batch.md
+++ b/docs/examples/batch.md
@@ -1,0 +1,228 @@
+# Batch Simulation Examples
+
+The `POST /api/simulate/batch` endpoint simulates multiple transactions in a single request. Results are returned in the same order as the input, with each entry indicating success or failure independently.
+
+## Request Format
+
+```json
+{
+  "transactions": [
+    { "xdr": "AAAAAgAAAAC..." },
+    { "xdr": "AAAAAgAAAAD..." }
+  ],
+  "network": "testnet"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transactions` | array | ✅ | Array of `{ xdr }` objects (max 100) |
+| `network` | string | ❌ | `"testnet"` or `"mainnet"` (default: `"testnet"`) |
+
+## Response Format
+
+```json
+{
+  "results": [
+    {
+      "index": 0,
+      "success": true,
+      "footprint": { "readOnly": ["..."], "readWrite": ["..."] },
+      "cost": { "cpuInsns": "1234567", "memBytes": "8192" }
+    },
+    {
+      "index": 1,
+      "success": false,
+      "error": "Transaction requires ledger entry restoration before simulation."
+    }
+  ]
+}
+```
+
+The response header `X-Cache` reflects cache status: `HIT`, `MISS`, or `PARTIAL` (some entries cached, some not).
+
+---
+
+## curl
+
+```bash
+curl -X POST http://localhost:3000/api/simulate/batch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transactions": [
+      { "xdr": "AAAAAgAAAAC..." },
+      { "xdr": "AAAAAgAAAAD..." },
+      { "xdr": "AAAAAgAAAAE..." }
+    ],
+    "network": "testnet"
+  }'
+```
+
+Handling mixed results with `jq`:
+
+```bash
+curl -s -X POST http://localhost:3000/api/simulate/batch \
+  -H "Content-Type: application/json" \
+  -d '{"transactions":[{"xdr":"AAAAAgAAAAC..."},{"xdr":"AAAAAgAAAAD..."}],"network":"testnet"}' \
+| jq '.results[] | if .success then "[\(.index)] OK: \(.cost.cpuInsns) cpu" else "[\(.index)] FAIL: \(.error)" end'
+```
+
+---
+
+## JavaScript
+
+```javascript
+const SERVICE_URL = "http://localhost:3000";
+
+async function simulateBatch(xdrList, network = "testnet") {
+  const response = await fetch(`${SERVICE_URL}/api/simulate/batch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      transactions: xdrList.map((xdr) => ({ xdr })),
+      network,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Batch request failed: ${response.status}`);
+  }
+
+  const { results } = await response.json();
+
+  const succeeded = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  console.log(`${succeeded.length} succeeded, ${failed.length} failed`);
+
+  for (const result of failed) {
+    console.error(`[${result.index}] ${result.error}`);
+  }
+
+  return results;
+}
+
+// Usage
+const xdrList = [
+  "AAAAAgAAAAC...",
+  "AAAAAgAAAAD...",
+  "AAAAAgAAAAE...",
+];
+
+simulateBatch(xdrList).then((results) => {
+  for (const r of results) {
+    if (r.success) {
+      console.log(`[${r.index}] readOnly: ${r.footprint.readOnly.length}, readWrite: ${r.footprint.readWrite.length}`);
+    }
+  }
+});
+```
+
+---
+
+## TypeScript
+
+```typescript
+const SERVICE_URL = "http://localhost:3000";
+
+interface FootprintResult {
+  index: number;
+  success: true;
+  footprint: { readOnly: string[]; readWrite: string[] };
+  cost: { cpuInsns: string; memBytes: string };
+  cacheHit?: boolean;
+}
+
+interface FailureResult {
+  index: number;
+  success: false;
+  error: string;
+}
+
+type BatchResult = FootprintResult | FailureResult;
+
+async function simulateBatch(
+  xdrList: string[],
+  network: "testnet" | "mainnet" = "testnet",
+): Promise<BatchResult[]> {
+  const response = await fetch(`${SERVICE_URL}/api/simulate/batch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      transactions: xdrList.map((xdr) => ({ xdr })),
+      network,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Batch request failed: ${response.status}`);
+  }
+
+  const { results }: { results: BatchResult[] } = await response.json();
+  return results;
+}
+
+// Usage
+const xdrList = ["AAAAAgAAAAC...", "AAAAAgAAAAD..."];
+
+simulateBatch(xdrList).then((results) => {
+  for (const result of results) {
+    if (result.success) {
+      console.log(`[${result.index}] cpu: ${result.cost.cpuInsns}`);
+    } else {
+      console.error(`[${result.index}] error: ${result.error}`);
+    }
+  }
+});
+```
+
+---
+
+## Python
+
+```python
+import requests
+
+SERVICE_URL = "http://localhost:3000"
+
+def simulate_batch(xdr_list: list[str], network: str = "testnet") -> list[dict]:
+    response = requests.post(
+        f"{SERVICE_URL}/api/simulate/batch",
+        json={
+            "transactions": [{"xdr": xdr} for xdr in xdr_list],
+            "network": network,
+        },
+    )
+    response.raise_for_status()
+    return response.json()["results"]
+
+
+# Usage
+xdr_list = [
+    "AAAAAgAAAAC...",
+    "AAAAAgAAAAD...",
+    "AAAAAgAAAAE...",
+]
+
+results = simulate_batch(xdr_list)
+
+succeeded = [r for r in results if r["success"]]
+failed = [r for r in results if not r["success"]]
+
+print(f"{len(succeeded)} succeeded, {len(failed)} failed")
+
+for r in succeeded:
+    print(f"[{r['index']}] readOnly={len(r['footprint']['readOnly'])}, cpu={r['cost']['cpuInsns']}")
+
+for r in failed:
+    print(f"[{r['index']}] ERROR: {r['error']}")
+```
+
+---
+
+## Notes
+
+- The batch endpoint processes transactions concurrently (controlled by `BATCH_CONCURRENCY`, default `5`).
+- Maximum batch size is `100` (controlled by `BATCH_MAX_SIZE` in the ConfigMap).
+- A single failed transaction does not fail the entire batch — check each result's `success` field.
+- The `index` field in each result corresponds to the position in the input `transactions` array.

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -1,0 +1,109 @@
+# Caching Guide
+
+The Stellar Footprint Service caches simulation results to avoid redundant RPC calls. Identical requests (same XDR + network) return the cached result instantly without hitting the Stellar RPC.
+
+---
+
+## Dual-Backend Strategy
+
+The service selects a cache backend at startup based on whether `REDIS_URL` is set:
+
+| Condition | Backend | Notes |
+|---|---|---|
+| `REDIS_URL` is set and Redis is reachable | **Redis** | Shared across all instances; survives restarts |
+| `REDIS_URL` is unset or Redis fails to connect | **In-memory LRU** | Per-process; lost on restart |
+
+If Redis connects but later drops, the service logs a warning and transparently falls back to the in-memory cache. No restart is required.
+
+You can confirm which backend is active by checking the startup log:
+
+```
+Cache backend: Redis
+# or
+Cache backend: in-memory LRU (REDIS_URL not set)
+```
+
+---
+
+## Cache Key Structure
+
+Cache keys are deterministic SHA-256 hashes of the request's canonical JSON (keys sorted alphabetically):
+
+```
+sha256(JSON.stringify({ network: "testnet", xdr: "AAAAAgAAAAC..." }))
+→ "a3f2c1d9e8b7..."
+```
+
+This means two requests with the same XDR and network always hit the same cache entry, regardless of field order in the request body.
+
+---
+
+## TTL Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `CACHE_TTL_SECONDS` | `60` | How long a cached result lives (seconds) |
+| `CACHE_MAX_SIZE` | `500` | Maximum entries in the in-memory LRU cache |
+| `REDIS_URL` | — | Full Redis connection URL (e.g. `redis://localhost:6379`) |
+| `REDIS_HOST` | `redis` | Redis hostname (Docker Compose only) |
+| `REDIS_PORT` | `6379` | Redis port (Docker Compose only) |
+
+> **Note:** `REDIS_URL` takes precedence over `REDIS_HOST`/`REDIS_PORT`. Use `REDIS_URL` for production deployments (supports `rediss://` for TLS).
+
+### Choosing a TTL
+
+- **Short TTL (30–60 s):** Good for development or when ledger state changes frequently.
+- **Longer TTL (5–30 min):** Appropriate for stable contracts where footprints rarely change. Reduces RPC load significantly under high traffic.
+
+---
+
+## Cache Invalidation
+
+### Automatic expiry
+
+Entries expire automatically after `CACHE_TTL_SECONDS`. No manual action needed.
+
+### Manual flush
+
+To immediately clear all cached entries (both Redis and in-memory):
+
+```bash
+curl -X DELETE http://localhost:3000/api/cache
+```
+
+Response:
+
+```json
+{ "message": "Cache cleared" }
+```
+
+**When to use `DELETE /cache`:**
+
+- After deploying a new contract version that changes footprint structure
+- When debugging unexpected cached responses
+- After a ledger migration or network reset on testnet
+
+---
+
+## Redis in Docker Compose
+
+The `docker-compose.yml` includes a Redis service. No extra configuration is needed for local development:
+
+```bash
+docker compose up
+```
+
+For production, use a managed Redis instance and set `REDIS_URL`:
+
+```env
+REDIS_URL=rediss://your-redis-host:6380
+```
+
+The `rediss://` scheme enables TLS. Most managed Redis providers (Upstash, Redis Cloud, AWS ElastiCache) require TLS in production.
+
+---
+
+## Further Reading
+
+- [ADR 001 — Caching Strategy](../adr/001-caching-strategy.md)
+- [Environment Variables Reference](../../README.md#-environment-variables)

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -1,0 +1,229 @@
+# Kubernetes Deployment Guide
+
+This guide covers deploying the Stellar Footprint Service to a Kubernetes cluster using the manifests in `k8s/`.
+
+---
+
+## Prerequisites
+
+- A running Kubernetes cluster (local: [minikube](https://minikube.sigs.k8s.io/) or [kind](https://kind.sigs.k8s.io/); cloud: EKS, GKE, AKS)
+- `kubectl` configured to target your cluster (`kubectl cluster-info`)
+- The service Docker image built and pushed to a registry accessible by your cluster
+
+Build and push the image:
+
+```bash
+docker build -t your-registry/stellar-footprint-service:latest .
+docker push your-registry/stellar-footprint-service:latest
+```
+
+Update the `image:` field in `k8s/deployment.yaml` to match your registry path.
+
+---
+
+## Manifests Overview
+
+| File | Purpose |
+|---|---|
+| `k8s/deployment.yaml` | Pod spec, resource limits, health probes |
+| `k8s/service.yaml` | ClusterIP service exposing port 80 → 3000 |
+| `k8s/hpa.yaml` | Horizontal Pod Autoscaler (2–10 replicas) |
+| `k8s/configmap.yaml` | Non-sensitive environment variables |
+| `k8s/secret.yaml.template` | Template for sensitive values (RPC URLs, keys) |
+
+---
+
+## Applying the Manifests
+
+### 1. Create a namespace (optional but recommended)
+
+```bash
+kubectl create namespace stellar-footprint
+```
+
+All subsequent commands use `-n stellar-footprint`. Omit the flag to deploy to the `default` namespace.
+
+### 2. Configure secrets
+
+Copy the secret template and fill in real values:
+
+```bash
+cp k8s/secret.yaml.template k8s/secret.yaml
+```
+
+Edit `k8s/secret.yaml`:
+
+```yaml
+stringData:
+  TESTNET_RPC_URL: "https://soroban-testnet.stellar.org"
+  MAINNET_RPC_URL: "https://mainnet.stellar.validationcloud.io/v1/<YOUR_API_KEY>"
+  TESTNET_SECRET_KEY: "<your_testnet_secret_key>"
+  MAINNET_SECRET_KEY: "<your_mainnet_secret_key>"
+```
+
+> **Never commit `k8s/secret.yaml`.** It is already listed in `.gitignore`. For production, prefer a secrets manager (AWS Secrets Manager, HashiCorp Vault, Sealed Secrets) over plain Kubernetes Secrets.
+
+Apply the secret:
+
+```bash
+kubectl apply -f k8s/secret.yaml -n stellar-footprint
+```
+
+### 3. Apply all remaining manifests
+
+```bash
+kubectl apply -f k8s/configmap.yaml -n stellar-footprint
+kubectl apply -f k8s/deployment.yaml -n stellar-footprint
+kubectl apply -f k8s/service.yaml -n stellar-footprint
+kubectl apply -f k8s/hpa.yaml -n stellar-footprint
+```
+
+Or apply the whole directory at once (secret must already exist):
+
+```bash
+kubectl apply -f k8s/ -n stellar-footprint
+```
+
+### 4. Verify the deployment
+
+```bash
+kubectl rollout status deployment/stellar-footprint-service -n stellar-footprint
+kubectl get pods -n stellar-footprint
+```
+
+Expected output:
+
+```
+NAME                                        READY   STATUS    RESTARTS   AGE
+stellar-footprint-service-6d9f8b7c4-abc12   1/1     Running   0          30s
+stellar-footprint-service-6d9f8b7c4-def34   1/1     Running   0          30s
+```
+
+### 5. Test the service
+
+Port-forward to test locally:
+
+```bash
+kubectl port-forward svc/stellar-footprint-service 8080:80 -n stellar-footprint
+curl http://localhost:8080/api/health
+```
+
+---
+
+## Configuring Secrets
+
+The deployment loads secrets from the `stellar-footprint-secrets` Kubernetes Secret. To update a value without redeploying:
+
+```bash
+kubectl patch secret stellar-footprint-secrets \
+  -n stellar-footprint \
+  --type='json' \
+  -p='[{"op":"replace","path":"/stringData/TESTNET_RPC_URL","value":"https://new-rpc-url"}]'
+
+kubectl rollout restart deployment/stellar-footprint-service -n stellar-footprint
+```
+
+To update ConfigMap values (non-sensitive):
+
+```bash
+kubectl patch configmap stellar-footprint-config \
+  -n stellar-footprint \
+  --type='merge' \
+  -p '{"data":{"LOG_LEVEL":"debug"}}'
+
+kubectl rollout restart deployment/stellar-footprint-service -n stellar-footprint
+```
+
+---
+
+## HPA Tuning
+
+The HPA in `k8s/hpa.yaml` scales between **2 and 10 replicas** based on CPU utilisation, targeting **70%** average utilisation.
+
+```yaml
+minReplicas: 2
+maxReplicas: 10
+metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+```
+
+**Tuning guidelines:**
+
+- Lower `averageUtilization` (e.g. `50`) to scale out earlier and reduce latency spikes under bursty load.
+- Increase `maxReplicas` if you expect sustained high traffic.
+- Ensure the Kubernetes Metrics Server is installed for HPA to function:
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+  ```
+- Check HPA status:
+  ```bash
+  kubectl get hpa -n stellar-footprint
+  ```
+
+---
+
+## Health Check Configuration
+
+The deployment configures two probes against the dedicated health endpoints:
+
+| Probe | Path | Purpose |
+|---|---|---|
+| Liveness | `GET /api/health/live` | Restarts the container if the process is stuck |
+| Readiness | `GET /api/health/ready` | Removes the pod from the load balancer until it is ready |
+
+Current settings in `k8s/deployment.yaml`:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health/live
+    port: 3000
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+```
+
+**Tuning guidelines:**
+
+- Increase `initialDelaySeconds` on the liveness probe if the service takes longer to start (e.g. slow Redis connection).
+- Decrease `periodSeconds` on the readiness probe for faster traffic recovery after a restart.
+- The readiness probe checks Redis and the RPC circuit breaker state. If Redis is unavailable, the pod will be marked not-ready until the in-memory fallback activates.
+
+---
+
+## Updating the Deployment
+
+```bash
+# Pull latest image and trigger a rolling update
+kubectl set image deployment/stellar-footprint-service \
+  stellar-footprint-service=your-registry/stellar-footprint-service:new-tag \
+  -n stellar-footprint
+
+# Monitor the rollout
+kubectl rollout status deployment/stellar-footprint-service -n stellar-footprint
+
+# Roll back if needed
+kubectl rollout undo deployment/stellar-footprint-service -n stellar-footprint
+```
+
+---
+
+## Further Reading
+
+- [k8s/README.md](../../k8s/README.md) — manifest-level reference
+- [Deployment Guide](../deployment.md) — Railway, Render, Fly.io, and VPS options


### PR DESCRIPTION
  
 Closes #394 — SECURITY.md
  
  - Added a GitHub Security Advisories private reporting link alongside the existing email
  - Bolded the timeline values for clarity; structure already matched GitHub's recommended format
  
 Closes #392 — docs/guides/caching.md (new file)
  
  - Explains the dual-backend strategy (Redis → in-memory LRU fallback)
  - Documents all cache-related env vars (CACHE_TTL_SECONDS, CACHE_MAX_SIZE, REDIS_URL, REDIS_HOST,
  REDIS_PORT)
  - Explains the SHA-256 cache key structure
  - Documents when and how to use DELETE /cache
  - Linked from README under a new ## 🗄️ Caching Guide section
  
 Closes #395 — docs/examples/batch.md (new file)
  
  - Full request/response format documentation
  - Examples in curl, JavaScript, TypeScript, and Python
  - Each example shows how to handle mixed success/failure results
  - Notes on BATCH_CONCURRENCY, BATCH_MAX_SIZE, and the X-Cache header
  
 Closes #393 — docs/guides/kubernetes.md (new file)
  
  - Prerequisites (cluster, kubectl, image registry)
  - Step-by-step: namespace, secrets, applying manifests, verification
  - Secrets and ConfigMap update commands
  - HPA tuning guidance (Metrics Server requirement, scaling thresholds)
  - Health check probe configuration and tuning tips
  - Linked from docs/deployment.md (ToC + new section #5) and README deployment table
 