### PR TITLE
test: add snapshot tests for API response shapes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,17 @@ Thank you for your interest in contributing! This guide covers everything you ne
 | `pnpm run format` | Format code with Prettier |
 | `pnpm run format:check` | Check formatting without writing |
 | `pnpm test` | Run test suite |
+| `pnpm test --updateSnapshot` | Refresh Jest snapshots after intentional response shape changes |
+
+### Updating Jest snapshots
+
+Snapshot coverage in this repository is maintained through Jest snapshots. When an endpoint response shape intentionally changes, refresh the snapshots with:
+
+```bash
+pnpm test --updateSnapshot
+```
+
+This updates inline snapshots and generated snapshot files in place. Review the updated snapshot blocks before committing.
 
 ---
 

--- a/src/__tests__/responseShapes.test.ts
+++ b/src/__tests__/responseShapes.test.ts
@@ -1,0 +1,266 @@
+import request from "supertest";
+
+import app from "../index";
+import { SOROBAN_INVOKE_XDR } from "../tests/fixtures/xdr";
+
+jest.mock("@services/simulator", () => ({
+  simulateTransaction: jest.fn(),
+  simulationCache: { get: jest.fn(), set: jest.fn() },
+}));
+
+jest.mock("@services/networkStatus", () => ({
+  getNetworkStatus: jest.fn(),
+}));
+
+jest.mock("@services/decoder", () => ({
+  decodeXdr: jest.fn(),
+}));
+
+jest.mock("@services/feeEstimator", () => ({
+  estimateFee: jest.fn(),
+  estimateFeeDetailed: jest.fn(),
+}));
+
+jest.mock("@middleware/metrics", () => ({
+  __esModule: true,
+  default: {
+    incrementActiveSimulations: jest.fn(),
+    decrementActiveSimulations: jest.fn(),
+    recordSimulation: jest.fn(),
+    recordSimulationDuration: jest.fn(),
+    recordCacheHit: jest.fn(),
+    recordCacheMiss: jest.fn(),
+    recordRpcError: jest.fn(),
+    recordXdrBytes: jest.fn(),
+    getMetrics: jest.fn().mockResolvedValue(""),
+  },
+  metricsMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  metrics: {
+    incrementActiveSimulations: jest.fn(),
+    decrementActiveSimulations: jest.fn(),
+    recordSimulation: jest.fn(),
+    recordSimulationDuration: jest.fn(),
+    recordCacheHit: jest.fn(),
+    recordCacheMiss: jest.fn(),
+    recordRpcError: jest.fn(),
+    recordXdrBytes: jest.fn(),
+    getMetrics: jest.fn().mockResolvedValue(""),
+  },
+}));
+
+import { decodeXdr } from "@services/decoder";
+import { estimateFee } from "@services/feeEstimator";
+import { getNetworkStatus } from "@services/networkStatus";
+import { simulateTransaction } from "@services/simulator";
+
+const mockSimulateTransaction = simulateTransaction as jest.MockedFunction<
+  typeof simulateTransaction
+>;
+const mockGetNetworkStatus = getNetworkStatus as jest.MockedFunction<
+  typeof getNetworkStatus
+>;
+const mockDecodeXdr = decodeXdr as jest.MockedFunction<typeof decodeXdr>;
+const mockEstimateFee = estimateFee as jest.MockedFunction<typeof estimateFee>;
+
+const MOCK_SIMULATION_SUCCESS = {
+  success: true,
+  footprint: {
+    readOnly: ["AAAABgAAAAAAA"],
+    readWrite: ["AAAABgAAAAAAB"],
+  },
+  contracts: ["CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+  contractType: "token" as const,
+  ttl: { liveUntilLedgerSeq: 12345 },
+  optimized: true,
+  rawFootprint: {
+    readOnly: ["AAAABgAAAAAAA"],
+    readWrite: ["AAAABgAAAAAAB"],
+  },
+  cost: {
+    cpuInsns: "123456",
+    memBytes: "4096",
+  },
+  cacheHit: false,
+};
+
+const MOCK_SIMULATION_ERROR = {
+  success: false,
+  error: "contract panic: assertion failed",
+};
+
+const MOCK_DECODE_RESULT = {
+  success: true,
+  type: "transaction" as const,
+  decoded: {
+    sourceAccount: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+    operations: [
+      {
+        type: "invokeHostFunction",
+        function: "hello",
+      },
+    ],
+  },
+};
+
+const MOCK_FEE_ESTIMATE = {
+  baseFee: "100",
+  resourceFee: "250",
+  totalFee: "350",
+  feeInXLM: "0.0000350",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));
+  jest.spyOn(process, "uptime").mockReturnValue(123.456);
+
+  mockSimulateTransaction.mockResolvedValue(MOCK_SIMULATION_SUCCESS as never);
+  mockGetNetworkStatus.mockResolvedValue({
+    ledger: 123456,
+    baseFee: "100",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    rpcLatencyMs: 17,
+  } as never);
+  mockDecodeXdr.mockReturnValue(MOCK_DECODE_RESULT as never);
+  mockEstimateFee.mockResolvedValue(MOCK_FEE_ESTIMATE as never);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe("endpoint response shape snapshots", () => {
+  it("captures /health response shape", async () => {
+    const response = await request(app).get("/api/v1/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "status": "ok",
+        "timestamp": "2026-01-02T03:04:05.000Z",
+        "uptime": 123.456,
+        "version": "1.0.0",
+      }
+    `);
+  });
+
+  it("captures successful /simulate response shape", async () => {
+    const response = await request(app)
+      .post("/api/v1/simulate")
+      .send({ xdr: SOROBAN_INVOKE_XDR, network: "testnet" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "cacheHit": false,
+        "contractType": "token",
+        "contracts": Array [
+          "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ],
+        "cost": Object {
+          "cpuInsns": "123456",
+          "memBytes": "4096",
+        },
+        "footprint": Object {
+          "readOnly": Array [
+            "AAAABgAAAAAAA",
+          ],
+          "readWrite": Array [
+            "AAAABgAAAAAAB",
+          ],
+        },
+        "optimized": true,
+        "rawFootprint": Object {
+          "readOnly": Array [
+            "AAAABgAAAAAAA",
+          ],
+          "readWrite": Array [
+            "AAAABgAAAAAAB",
+          ],
+        },
+        "success": true,
+        "ttl": Object {
+          "liveUntilLedgerSeq": 12345,
+        },
+      }
+    `);
+  });
+
+  it("captures failed /simulate response shape", async () => {
+    mockSimulateTransaction.mockResolvedValueOnce(MOCK_SIMULATION_ERROR as never);
+
+    const response = await request(app)
+      .post("/api/v1/simulate")
+      .send({ xdr: SOROBAN_INVOKE_XDR, network: "testnet" });
+
+    expect(response.status).toBe(422);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "error": "contract panic: assertion failed",
+        "success": false,
+      }
+    `);
+  });
+
+  it("captures /network/status response shape", async () => {
+    const response = await request(app).get("/api/v1/network/status");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "baseFee": "100",
+          "ledger": 123456,
+          "networkPassphrase": "Test SDF Network ; September 2015",
+          "rpcLatencyMs": 17,
+        },
+        "success": true,
+      }
+    `);
+  });
+
+  it("captures /decode response shape", async () => {
+    const response = await request(app)
+      .get("/api/v1/decode")
+      .query({ xdr: SOROBAN_INVOKE_XDR, type: "transaction" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "decoded": Object {
+          "operations": Array [
+            Object {
+              "function": "hello",
+              "type": "invokeHostFunction",
+            },
+          ],
+          "sourceAccount": "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+        },
+        "success": true,
+        "type": "transaction",
+      }
+    `);
+  });
+
+  it("captures /estimate-fee response shape", async () => {
+    const response = await request(app)
+      .post("/api/v1/estimate-fee")
+      .send({
+        cpuInsns: "100000",
+        memBytes: "2048",
+        network: "testnet",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchInlineSnapshot(`
+      Object {
+        "baseFee": "100",
+        "feeInXLM": "0.0000350",
+        "resourceFee": "250",
+        "totalFee": "350",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
### Changes made
1. Added dedicated endpoint response-shape snapshot coverage in responseShapes.test.ts.
   - Covers:
     - `/health`
     - `/simulate` success
     - `/simulate` error
     - `/network/status`
     - `/decode`
     - `/estimate-fee`
   - Uses deterministic mocks so snapshot shapes stay stable across runs.

2. Documented snapshot refresh instructions in CONTRIBUTING.md.
   - Added the `pnpm test --updateSnapshot` workflow and guidance for reviewing updated snapshots.

> No test commands were run.

Made changes.

Closes #375 