### PR TITLE
feat: resolve issues #339 #340 #341 #342

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ Thumbs.db
 # Test artifacts
 apps/contracts/*/test_snapshots/
 proptest-regressions/
+**/__snapshots__/
+*.snap
 
 # JS / Node
 node_modules/

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -307,3 +307,9 @@ components:
         error:
           type: string
           description: Human-readable error message
+        code:
+          type: string
+          description: Machine-readable error code (optional)
+        requestId:
+          type: string
+          description: Request correlation ID from X-Request-ID header

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { bruteForceMiddleware } from "./middleware/bruteForce";
 import { contentTypeMiddleware } from "./middleware/contentType";
 import { errorHandler } from "./middleware/errorHandler";
 import { ipFilterMiddleware } from "./middleware/ipFilter";
+import { httpCacheMiddleware } from "./middleware/httpCache";
 import { metricsMiddleware, metrics } from "./middleware/metrics";
 import { requestIdMiddleware } from "./middleware/requestId";
 import { requestLogger } from "./middleware/requestLogger";
@@ -86,6 +87,7 @@ app.use(metricsMiddleware);
 app.use(timeoutMiddleware);
 app.use(bruteForceMiddleware);
 app.use(contentTypeMiddleware);
+app.use(httpCacheMiddleware);
 
 // Swagger UI — development only
 if (process.env.NODE_ENV !== "production") {

--- a/src/middleware/__tests__/errorHandler.test.ts
+++ b/src/middleware/__tests__/errorHandler.test.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from "express";
 import { AppError } from "../../utils/AppError";
 import { errorHandler } from "../errorHandler";
 
-function makeRes() {
+function makeRes(requestId?: string) {
   const headers: Record<string, string> = {};
   return {
     set: jest.fn((k: string, v: string) => {
@@ -11,6 +11,7 @@ function makeRes() {
     }),
     status: jest.fn().mockReturnThis(),
     json: jest.fn(),
+    locals: { requestId },
     _headers: headers,
   } as unknown as Response & { _headers: Record<string, string> };
 }
@@ -78,5 +79,35 @@ describe("errorHandler", () => {
     errorHandler(err, makeReq(), res, next);
 
     expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it("includes requestId in error response body when set (#340)", () => {
+    const err = new AppError("Missing required field: xdr", 400);
+    const res = makeRes("test-request-id-123");
+    errorHandler(err, makeReq(), res, next);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.requestId).toBe("test-request-id-123");
+  });
+
+  it("omits requestId when not set (#340)", () => {
+    const err = new AppError("Missing required field: xdr", 400);
+    const res = makeRes(undefined);
+    errorHandler(err, makeReq(), res, next);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.requestId).toBeUndefined();
+  });
+
+  it("includes requestId in circuit-open error response (#340)", () => {
+    const err = Object.assign(new Error("Circuit breaker is open"), {
+      circuitOpen: true as const,
+      retryAfter: 10,
+    });
+    const res = makeRes("req-abc-456");
+    errorHandler(err, makeReq(), res, next);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.requestId).toBe("req-abc-456");
   });
 });

--- a/src/middleware/__tests__/hmacVerify.test.ts
+++ b/src/middleware/__tests__/hmacVerify.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #342 — HMAC-SHA256 webhook signature verification tests
+ */
+import crypto from "crypto";
+
+import { Request, Response, NextFunction } from "express";
+
+import { hmacVerify, WEBHOOK_SIGNATURE_HEADER } from "../hmacVerify";
+
+const SECRET = "test-webhook-secret";
+const BODY = { event: "simulate.complete", id: "abc123" };
+
+function sign(body: object, secret: string): string {
+  const raw = Buffer.from(JSON.stringify(body));
+  return `sha256=${crypto.createHmac("sha256", secret).update(raw).digest("hex")}`;
+}
+
+function makeReqRes(signature?: string, body: object = BODY) {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as Response;
+
+  const req = {
+    headers: signature ? { [WEBHOOK_SIGNATURE_HEADER]: signature } : {},
+    body,
+  } as unknown as Request;
+
+  return { req, res };
+}
+
+const next: NextFunction = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.WEBHOOK_VERIFY_SECRET = SECRET;
+});
+
+afterEach(() => {
+  delete process.env.WEBHOOK_VERIFY_SECRET;
+});
+
+describe("hmacVerify (#342)", () => {
+  it("calls next() for a valid signature", () => {
+    const { req, res } = makeReqRes(sign(BODY, SECRET));
+    hmacVerify(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when signature header is missing", () => {
+    const { req, res } = makeReqRes(undefined);
+    hmacVerify(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining("Missing") }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an invalid signature", () => {
+    const { req, res } = makeReqRes("sha256=invalidsignature");
+    hmacVerify(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining("Invalid") }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when secret is not configured", () => {
+    delete process.env.WEBHOOK_VERIFY_SECRET;
+    const { req, res } = makeReqRes(sign(BODY, SECRET));
+    hmacVerify(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining("not configured") }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when signature is for a different secret", () => {
+    const { req, res } = makeReqRes(sign(BODY, "wrong-secret"));
+    hmacVerify(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/__tests__/httpCache.test.ts
+++ b/src/middleware/__tests__/httpCache.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #341 — ETag / Cache-Control / 304 caching headers tests
+ */
+import crypto from "crypto";
+
+import { Request, Response, NextFunction } from "express";
+
+import { httpCacheMiddleware } from "../httpCache";
+
+function makeReqRes(ifNoneMatch?: string) {
+  const headers: Record<string, string | undefined> = {
+    "if-none-match": ifNoneMatch,
+  };
+  const resHeaders: Record<string, string> = {};
+  let statusCode = 200;
+
+  const res = {
+    statusCode,
+    setHeader: jest.fn((k: string, v: string) => {
+      resHeaders[k.toLowerCase()] = v;
+    }),
+    removeHeader: jest.fn(),
+    status: jest.fn().mockImplementation((code: number) => {
+      statusCode = code;
+      res.statusCode = code;
+      return res;
+    }),
+    end: jest.fn(),
+    json: jest.fn().mockReturnThis(),
+    _headers: resHeaders,
+    get statusCodeValue() {
+      return statusCode;
+    },
+  } as unknown as Response & { _headers: Record<string, string> };
+
+  const req = {
+    headers,
+  } as unknown as Request;
+
+  return { req, res, resHeaders };
+}
+
+describe("httpCacheMiddleware (#341)", () => {
+  it("sets ETag and Cache-Control on 200 responses", () => {
+    const { req, res, resHeaders } = makeReqRes();
+    const next: NextFunction = jest.fn();
+
+    httpCacheMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+
+    // Simulate the controller calling res.json
+    const body = { success: true, data: "test" };
+    res.json(body);
+
+    const payload = JSON.stringify(body);
+    const expectedEtag = `"${crypto.createHash("sha256").update(payload).digest("hex")}"`;
+
+    expect(resHeaders["etag"]).toBe(expectedEtag);
+    expect(resHeaders["cache-control"]).toBe("public, max-age=60");
+  });
+
+  it("returns 304 when If-None-Match matches ETag", () => {
+    const body = { success: true, data: "cached" };
+    const payload = JSON.stringify(body);
+    const etag = `"${crypto.createHash("sha256").update(payload).digest("hex")}"`;
+
+    const { req, res } = makeReqRes(etag);
+    const next: NextFunction = jest.fn();
+
+    httpCacheMiddleware(req, res, next);
+    res.json(body);
+
+    expect(res.status).toHaveBeenCalledWith(304);
+    expect(res.end).toHaveBeenCalled();
+    // json should NOT have been called with the body (we short-circuit)
+    expect(res.json).not.toHaveBeenCalledWith(body);
+  });
+
+  it("does not set Cache-Control on non-200 responses", () => {
+    const { req, res, resHeaders } = makeReqRes();
+    const next: NextFunction = jest.fn();
+
+    res.statusCode = 400;
+    httpCacheMiddleware(req, res, next);
+    res.json({ error: "bad request" });
+
+    expect(resHeaders["cache-control"]).toBeUndefined();
+    expect(resHeaders["etag"]).toBeUndefined();
+  });
+});

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -36,7 +36,8 @@ export function errorHandler(
     res.status(503).json({
       success: false,
       error: t.CIRCUIT_OPEN,
-    } satisfies ResponseEnvelope);
+      ...(res.locals.requestId ? { requestId: res.locals.requestId as string } : {}),
+    } satisfies ResponseEnvelope & { requestId?: string });
     return;
   }
 
@@ -47,9 +48,10 @@ export function errorHandler(
   const key = enValueToKey[rawMessage];
   const message = key ? (t[key] as string) : rawMessage;
 
-  const response: ResponseEnvelope = {
+  const response: ResponseEnvelope & { requestId?: string } = {
     success: false,
     error: message,
+    ...(res.locals.requestId ? { requestId: res.locals.requestId as string } : {}),
   };
 
   res.status(statusCode).json(response);

--- a/src/middleware/hmacVerify.ts
+++ b/src/middleware/hmacVerify.ts
@@ -1,0 +1,57 @@
+import crypto from "crypto";
+
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * #342 — HMAC-SHA256 signature verification middleware for inbound webhook routes.
+ *
+ * Expects the caller to send the signature in the `X-Webhook-Signature` header
+ * as `sha256=<hex-digest>`. The shared secret is read from the
+ * `WEBHOOK_VERIFY_SECRET` environment variable.
+ *
+ * Returns 401 if the header is missing, the secret is not configured, or the
+ * signature does not match.
+ */
+export const WEBHOOK_SIGNATURE_HEADER = "x-webhook-signature";
+
+export function hmacVerify(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const secret = process.env.WEBHOOK_VERIFY_SECRET;
+
+  if (!secret) {
+    res.status(401).json({ error: "Webhook secret not configured" });
+    return;
+  }
+
+  const signature = req.headers[WEBHOOK_SIGNATURE_HEADER] as string | undefined;
+
+  if (!signature) {
+    res.status(401).json({ error: "Missing webhook signature" });
+    return;
+  }
+
+  const rawBody: Buffer =
+    (req as Request & { rawBody?: Buffer }).rawBody ??
+    Buffer.from(JSON.stringify(req.body));
+
+  const expected = `sha256=${crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex")}`;
+
+  const sigBuffer = Buffer.from(signature);
+  const expBuffer = Buffer.from(expected);
+
+  if (
+    sigBuffer.length !== expBuffer.length ||
+    !crypto.timingSafeEqual(sigBuffer, expBuffer)
+  ) {
+    res.status(401).json({ error: "Invalid webhook signature" });
+    return;
+  }
+
+  next();
+}

--- a/src/middleware/httpCache.ts
+++ b/src/middleware/httpCache.ts
@@ -1,0 +1,42 @@
+import crypto from "crypto";
+
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * #341 — HTTP caching headers middleware for successful simulation responses.
+ *
+ * - Sets ETag (SHA-256 of response body) on every response.
+ * - Sets Cache-Control: public, max-age=60 on 200 responses.
+ * - Returns 304 Not Modified when the client's If-None-Match matches the ETag.
+ */
+export function httpCacheMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const originalJson = res.json.bind(res);
+
+  res.json = function (body: unknown): Response {
+    const statusCode = res.statusCode;
+
+    if (statusCode === 200) {
+      const payload = JSON.stringify(body);
+      const etag = `"${crypto.createHash("sha256").update(payload).digest("hex")}"`;
+
+      res.setHeader("ETag", etag);
+      res.setHeader("Cache-Control", "public, max-age=60");
+
+      const ifNoneMatch = req.headers["if-none-match"];
+      if (ifNoneMatch === etag) {
+        res.removeHeader("Content-Type");
+        res.removeHeader("Content-Length");
+        res.status(304).end();
+        return res;
+      }
+    }
+
+    return originalJson(body);
+  };
+
+  next();
+}

--- a/src/tests/metricsCompression.test.ts
+++ b/src/tests/metricsCompression.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #339 — Verify gzip compression is applied to the /metrics endpoint
+ *
+ * The compression middleware is registered globally in index.ts before the
+ * /metrics route, so any response body that exceeds COMPRESSION_THRESHOLD
+ * bytes should be gzip-encoded when the client sends Accept-Encoding: gzip.
+ */
+
+const THRESHOLD = 128;
+process.env.COMPRESSION_THRESHOLD = String(THRESHOLD);
+
+// Minimal metrics mock — make getMetrics return a payload larger than threshold
+jest.mock("@middleware/metrics", () => {
+  const largePayload = "# HELP metric info\n".repeat(20); // well above 128 bytes
+  return {
+    __esModule: true,
+    metricsMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+      next(),
+    metrics: {
+      incrementActiveSimulations: jest.fn(),
+      decrementActiveSimulations: jest.fn(),
+      recordSimulation: jest.fn(),
+      recordSimulationDuration: jest.fn(),
+      recordCacheHit: jest.fn(),
+      recordCacheMiss: jest.fn(),
+      recordRpcError: jest.fn(),
+      recordXdrBytes: jest.fn(),
+      getMetrics: jest.fn().mockResolvedValue(largePayload),
+      getRegister: jest.fn(),
+    },
+    default: {
+      incrementActiveSimulations: jest.fn(),
+      decrementActiveSimulations: jest.fn(),
+      recordSimulation: jest.fn(),
+      recordSimulationDuration: jest.fn(),
+      recordCacheHit: jest.fn(),
+      recordCacheMiss: jest.fn(),
+      recordRpcError: jest.fn(),
+      recordXdrBytes: jest.fn(),
+      getMetrics: jest.fn().mockResolvedValue(largePayload),
+      getRegister: jest.fn(),
+    },
+  };
+});
+
+import request from "supertest";
+
+import app from "../index";
+
+describe("/metrics compression (#339)", () => {
+  it("compresses /metrics response when payload exceeds threshold and client accepts gzip", async () => {
+    const res = await request(app)
+      .get("/metrics")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+  });
+
+  it("does not compress /metrics when client does not accept gzip", async () => {
+    const res = await request(app)
+      .get("/metrics")
+      .set("Accept-Encoding", "identity");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"] ?? "").not.toBe("gzip");
+  });
+});


### PR DESCRIPTION
#339 - Add /metrics compression test verifying gzip when payload exceeds
       COMPRESSION_THRESHOLD (middleware was already applied globally)
#340 - Include requestId in all error response bodies; update OpenAPI
       ErrorResponse schema with requestId and code fields; add tests
#341 - Add httpCacheMiddleware: ETag (SHA-256), Cache-Control: public max-age=60
       on 200 responses, 304 Not Modified on If-None-Match match; add tests
#342 - Add hmacVerify middleware reading WEBHOOK_VERIFY_SECRET; returns 401
       on missing/invalid signature; add tests for valid and invalid cases
chore: extend .gitignore with __snapshots__/ and *.snap
Closes #339 
Closes #340 
Closes #341 
Closes #342 