### PR TITLE
docs: add ADR 003, error handling guide, monitoring guide, and update OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,14 @@ For a beginner-friendly guide explaining what Soroban footprints are, why they a
 
 For details on the Redis vs in-memory dual-backend strategy, TTL configuration, cache key structure, and when to use `DELETE /cache`, see [docs/guides/caching.md](./docs/guides/caching.md).
 
+## ⚠️ Error Handling Guide
+
+For a full reference of error codes, HTTP status codes, response shapes, and retry recommendations, see [docs/guides/error-handling.md](./docs/guides/error-handling.md).
+
+## 📊 Monitoring Guide
+
+For production monitoring setup (Prometheus + Grafana), available metrics, dashboard import, and alerting recommendations, see [docs/guides/monitoring.md](./docs/guides/monitoring.md).
+
 ## 🧩 Integration Guide
 
 ### Step 1: Build Transaction

--- a/docs/adr/003-rate-limiting.md
+++ b/docs/adr/003-rate-limiting.md
@@ -1,0 +1,114 @@
+# ADR 003: Rate Limiting Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+The Stellar Footprint Service exposes a public HTTP API that proxies calls to the Stellar RPC network. Without protection, a single client can exhaust the service's concurrency budget, spike RPC costs, or use the `/simulate` endpoint as a vector for brute-force enumeration of contract states.
+
+Two distinct threat profiles must be addressed:
+
+1. **Burst / volumetric abuse** — a client sends far more requests per minute than any legitimate use case requires, saturating RPC connections and degrading service for other users.
+2. **Brute-force / credential stuffing** — a client sends repeated requests that fail (invalid XDR, wrong network, contract panics) to probe contract state or discover valid inputs.
+
+A single rate-limiting primitive cannot serve both profiles well without either being too restrictive for normal traffic or too permissive for sustained low-and-slow abuse.
+
+## Decision
+
+We implement **two independent middleware layers**, each targeting one threat profile:
+
+### Layer 1 — General Rate Limiter (`express-rate-limit`)
+
+`src/middleware/rateLimiter.ts` wraps the `POST /simulate` route with a sliding-window counter using the `express-rate-limit` library.
+
+- **Window**: configurable via `RATE_LIMIT_WINDOW_MS` (default 60 000 ms)
+- **Limit**: configurable via `RATE_LIMIT_MAX` (default 60 requests per window)
+- **Key**: client IP address (standard `express-rate-limit` behaviour)
+- **Headers**: both draft-7 `RateLimit-*` standard headers and legacy `X-RateLimit-*` headers are emitted so that old and new clients both see the state
+- **Response on violation**: `429` with a JSON body containing `error`, `message`, and `retryAfter` (seconds)
+
+This layer only applies to `/simulate`. Health, decode, and utility endpoints are not rate-limited to avoid blocking monitoring tools and load-balancer probes.
+
+### Layer 2 — Brute Force Protection (`bruteForce` middleware)
+
+`src/middleware/bruteForce.ts` is a lightweight in-process IP tracker applied after the general rate limiter.
+
+- **Window**: configurable via `BRUTE_FORCE_WINDOW_MS` (default 60 000 ms)
+- **Delay threshold**: configurable via `BRUTE_FORCE_DELAY_THRESHOLD` (default 10 failures); once reached, each subsequent request from that IP incurs an artificial delay of `BRUTE_FORCE_DELAY_MS` (default 5 000 ms)
+- **Block threshold**: configurable via `BRUTE_FORCE_BLOCK_THRESHOLD` (default 20 failures); once reached, the IP is hard-blocked for `BRUTE_FORCE_BLOCK_MS` (default 300 000 ms = 5 min)
+- **Storage**: in-process `Map<string, IpRecord>` — intentionally not shared across replicas (see Consequences)
+- **Failure recording**: callers invoke `recordFailure(ip)` after a request results in a simulation error, to increment the counter for that IP
+
+### Why Two Layers?
+
+| Concern | Layer 1 | Layer 2 |
+|---|---|---|
+| Normal burst traffic | Caps total volume per IP | Not involved |
+| Repeated failures / probing | Not aware of success/failure | Delays then blocks |
+| Applies to | `/simulate` route only | Any route that calls `recordFailure` |
+| State | Stateless (window counter) | Stateful (success/failure count) |
+
+Combining both layers means a client that sends 60 legitimate requests per minute is not penalised, while a client that sends even 20 *failing* requests within a minute is blocked without needing to hit the global rate limit first.
+
+### Configuration Approach
+
+All thresholds are read from environment variables with safe defaults so that operators can tune per-deployment without code changes:
+
+| Variable | Default | Description |
+|---|---|---|
+| `RATE_LIMIT_MAX` | `60` | Maximum requests per window (Layer 1) |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Window duration in ms (Layer 1) |
+| `BRUTE_FORCE_DELAY_THRESHOLD` | `10` | Failure count before adding delay (Layer 2) |
+| `BRUTE_FORCE_BLOCK_THRESHOLD` | `20` | Failure count before hard block (Layer 2) |
+| `BRUTE_FORCE_WINDOW_MS` | `60000` | Window duration for failure counting (Layer 2) |
+| `BRUTE_FORCE_DELAY_MS` | `5000` | Artificial delay added after threshold (Layer 2) |
+| `BRUTE_FORCE_BLOCK_MS` | `300000` | Hard block duration (Layer 2) |
+
+### Redis vs In-Memory Trade-offs
+
+Both layers currently use **in-process state**. This was a deliberate choice for the initial implementation:
+
+**In-memory (current)**
+
+- Zero operational dependencies — works in local dev and single-replica deployments with no extra setup
+- Sub-millisecond counter increments with no network round-trip
+- State is lost on restart, which is acceptable: a restarted pod is effectively a new IP from the perspective of an attacker
+
+**Redis (future consideration)**
+
+- Required for accurate enforcement across multiple replicas; without it, a client can bypass Layer 1 by spreading requests across pods
+- Adds a network round-trip on every request (~1–5 ms) and a hard dependency on Redis availability
+- `express-rate-limit` supports a Redis store via `rate-limit-redis`; Layer 2 would need a custom Redis-backed store
+
+The trade-off: in-process state is sufficient when running a single replica or when approximate enforcement is acceptable. Shared Redis enforcement should be added when horizontal scaling makes per-pod limits meaningfully bypassable.
+
+## Consequences
+
+### Positive
+
+- **Immediate protection** with no external dependencies for common single-instance deployments
+- **Configurable without code changes** — operators can tighten or relax limits via environment variables
+- **Standard headers** (`RateLimit-Policy`, `RateLimit`, `Retry-After`) let well-behaved clients back off automatically
+- **Separation of concerns** — volumetric and brute-force threats are handled by independent, testable units
+
+### Negative
+
+- **No cross-replica coordination**: In a multi-pod deployment, each pod applies limits independently. A client that spreads traffic across N pods can make up to N × `RATE_LIMIT_MAX` requests before any single pod triggers a 429.
+- **IP accuracy**: Limits key on `req.ip`. Behind a NAT or shared proxy, all users share one IP counter. Operators running behind a load balancer must ensure `trust proxy` is set so `req.ip` reflects the real client IP, not the proxy.
+- **Memory growth (Layer 2)**: The `ipRecords` Map grows unboundedly if many unique IPs make failing requests. A future improvement is to add a periodic sweep that removes records whose windows have expired.
+
+## Alternatives Considered
+
+1. **Single rate limiter for everything**: Rejected. A global limit cannot distinguish between a bursty-but-legitimate client and a low-rate brute-force attacker.
+
+2. **Redis-backed rate limiting from day one**: Rejected for the initial implementation due to added operational complexity. The in-process approach covers the common single-replica deployment and can be upgraded without changing the API contract.
+
+3. **API key authentication**: Considered as a complement to IP-based limiting — keys allow per-client quotas and attribution. Deferred; the service is currently designed for public, unauthenticated access.
+
+4. **External WAF / API gateway**: Suitable for production-scale deployments but out of scope for the application layer. The middleware approach is self-contained and works in any deployment topology.
+
+## Related Issues
+
+- [Issue #77: Add ADR 003 for rate limiting strategy](https://github.com/Dafuriousis/Stellar-Footprint-Service/issues/77)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ This directory contains Architecture Decision Records for the Stellar Footprint 
 
 - [ADR 001: Caching Strategy](./001-caching-strategy.md) - Documents the decision to use in-memory LRU cache with optional Redis backend
 - [ADR 002: Circuit Breaker](./002-circuit-breaker.md) - Documents the three-state circuit breaker wrapping outbound RPC calls
+- [ADR 003: Rate Limiting Strategy](./003-rate-limiting.md) - Documents the two-layer rate limiting design (express-rate-limit + brute force protection)
 
 ## What is an ADR?
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,242 @@
+# Error Handling Guide
+
+This guide documents all error types, HTTP status codes, and error response shapes returned by the Stellar Footprint Service API. Use it to build robust retry and error-handling logic in your client.
+
+## Response Envelope
+
+All API responses — success and error — use the same top-level envelope:
+
+```json
+{
+  "success": true | false,
+  "data": { ... },   // present on success responses
+  "error": "..."     // present on error responses
+}
+```
+
+A few endpoints (notably `/simulate`, `/simulate/batch`, and `/estimate-fee`) return a flatter shape that omits the `success` wrapper; those are documented in the endpoint-specific sections below.
+
+---
+
+## HTTP Status Codes
+
+### 200 OK
+
+The request was accepted and processed successfully.
+
+```json
+{
+  "success": true,
+  "data": { ... }
+}
+```
+
+---
+
+### 400 Bad Request
+
+The request is malformed or missing required fields. No simulation or external call was attempted.
+
+**Common causes**
+
+| Cause | Example message |
+|---|---|
+| `xdr` field absent from body | `"Missing required field: xdr"` |
+| `xdr` is empty string or whitespace | `"Missing required field: xdr"` |
+| `network` is not `testnet`, `mainnet`, or `futurenet` | `"Invalid network. Use 'testnet', 'mainnet', or 'futurenet'"` |
+| Batch `transactions` array is missing or empty | `"Missing required field: transactions (must be a non-empty array)"` |
+| Batch size exceeds 10 | `"Batch size exceeds maximum of 10 transactions"` |
+| `cpuInsns` or `memBytes` are not integer strings | `"cpuInsns and memBytes must be non-negative integer strings"` |
+| XDR decode `type` parameter is unsupported | `"Invalid type. Supported types: transaction, operation, ledger_key"` |
+| XDR base64 cannot be parsed | `"Failed to decode XDR: ..."` |
+
+**Example — missing XDR**
+
+```http
+POST /api/v1/simulate
+Content-Type: application/json
+
+{ "network": "testnet" }
+```
+
+```json
+{
+  "success": false,
+  "error": "Missing required field: xdr"
+}
+```
+
+**Example — invalid network**
+
+```json
+{
+  "success": false,
+  "error": "Invalid network. Use 'testnet', 'mainnet', or 'futurenet'"
+}
+```
+
+---
+
+### 401 Unauthorized
+
+The service does not currently issue `401` responses. Authentication is not required for any public endpoint. If you receive a `401`, it is being emitted by an upstream proxy or API gateway.
+
+---
+
+### 422 Unprocessable Entity
+
+The request was well-formed and passed validation, but processing failed. The XDR was parseable but the Stellar RPC rejected the simulation.
+
+**Common causes**
+
+| Cause | Example message |
+|---|---|
+| Contract execution panic or assertion failure | `"contract panic: assertion failed"` |
+| Ledger entry expired — restore required before simulating | `"Transaction requires ledger entry restoration before simulation."` |
+| RPC returned a simulation error | RPC error message forwarded verbatim |
+| `transactionData` missing from a successful RPC response | `"Simulation succeeded but transactionData is missing; cannot extract footprint."` |
+
+**Example — contract error**
+
+```json
+{
+  "success": false,
+  "error": "contract panic: assertion failed"
+}
+```
+
+**Example — restoration required**
+
+```json
+{
+  "success": false,
+  "error": "Transaction requires ledger entry restoration before simulation."
+}
+```
+
+When you receive this error from `/simulate`, call `POST /api/v1/restore` with the same XDR to obtain a restoration transaction. Submit and confirm that transaction on-chain, then retry `/simulate`.
+
+---
+
+### 429 Too Many Requests
+
+The client has exceeded the rate limit for the `/simulate` endpoint.
+
+**Response headers**
+
+| Header | Description |
+|---|---|
+| `RateLimit-Limit` | Maximum requests allowed in the window |
+| `RateLimit-Remaining` | Requests remaining in the current window |
+| `RateLimit-Reset` | Unix timestamp (seconds) when the window resets |
+| `X-RateLimit-Limit` | Legacy alias for `RateLimit-Limit` |
+| `X-RateLimit-Remaining` | Legacy alias for `RateLimit-Remaining` |
+| `X-RateLimit-Reset` | Legacy alias for `RateLimit-Reset` |
+| `Retry-After` | Seconds to wait before retrying |
+
+**Example**
+
+```json
+{
+  "error": "Too Many Requests",
+  "message": "Rate limit exceeded. Try again in 60 seconds.",
+  "retryAfter": 60
+}
+```
+
+**Brute-force block (also 429)**
+
+IPs that exceed the failure threshold (`BRUTE_FORCE_BLOCK_THRESHOLD`, default 20 failed requests per window) are temporarily blocked for `BRUTE_FORCE_BLOCK_MS` (default 5 minutes).
+
+```json
+{
+  "error": "Too many failed requests. Try again later.",
+  "retryAfter": 287
+}
+```
+
+**Client guidance**: read the `Retry-After` header and back off for at least that many seconds before retrying. Do not hammer the endpoint — repeated violations reset the window and extend the block.
+
+---
+
+### 500 Internal Server Error
+
+An unexpected error occurred inside the service. The request was valid, but processing failed due to an unhandled condition.
+
+**Example**
+
+```json
+{
+  "success": false,
+  "error": "Unexpected error"
+}
+```
+
+`500` responses are logged server-side with full stack traces. If you encounter a persistent `500`, open an issue with the request body (redact any secrets) and the approximate timestamp.
+
+---
+
+### 503 Service Unavailable
+
+The RPC circuit breaker is open. The Stellar RPC endpoint has returned too many consecutive failures (`CB_FAILURE_THRESHOLD`, default 5) and the service has stopped forwarding traffic to protect itself and the RPC from further load.
+
+**Response header**
+
+| Header | Description |
+|---|---|
+| `Retry-After` | Seconds until the circuit breaker will attempt recovery |
+
+**Example**
+
+```json
+{
+  "success": false,
+  "error": "RPC circuit breaker is open. Try again later."
+}
+```
+
+The circuit breaker automatically attempts recovery after `CB_RECOVERY_MS` (default 30 seconds). A single probe request is sent; if it succeeds, the breaker closes and normal traffic resumes. Clients should honour `Retry-After` and not retry immediately.
+
+---
+
+## Error Field Reference
+
+| Field | Type | Present on | Description |
+|---|---|---|---|
+| `success` | boolean | All responses | `false` for all errors |
+| `error` | string | All error responses | Human-readable error message |
+| `message` | string | 429 rate-limit only | Extended message with retry guidance |
+| `retryAfter` | integer | 429 responses | Seconds to wait before retrying |
+
+---
+
+## Internationalization
+
+Error messages are returned in the language requested via the `Accept-Language` header when a translation is available. Currently supported: `en` (default), `es`.
+
+```http
+GET /api/v1/health
+Accept-Language: es
+```
+
+The `error` field in the response body will contain the translated message.
+
+---
+
+## Retry Recommendations
+
+| Status | Retry? | Strategy |
+|---|---|---|
+| 400 | No | Fix the request — retrying without changes will produce the same error |
+| 422 (contract error) | No | The contract rejected the transaction; investigate the XDR |
+| 422 (restore required) | Yes, after restore | Call `/restore`, submit the restore transaction, then retry |
+| 429 | Yes, after delay | Wait for `Retry-After` seconds |
+| 500 | Yes, with backoff | Transient; retry with exponential backoff (3 attempts max) |
+| 503 | Yes, after delay | Wait for `Retry-After` seconds |
+
+---
+
+## Related
+
+- [Rate Limiting Strategy — ADR 003](../adr/003-rate-limiting.md)
+- [OpenAPI Specification](../../openapi.yaml)

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -1,0 +1,268 @@
+# Monitoring Guide
+
+This guide covers production monitoring for the Stellar Footprint Service using Prometheus and Grafana.
+
+## Architecture Overview
+
+```
+┌─────────────────┐    scrape /metrics    ┌─────────────────┐    query    ┌─────────────────┐
+│ Stellar Service │──────────────────────▶│   Prometheus    │───────────▶│     Grafana     │
+│   (Port 3000)   │                       │   (Port 9090)   │            │   (Port 3001)   │
+└─────────────────┘                       └─────────────────┘            └─────────────────┘
+```
+
+Prometheus scrapes the `/metrics` endpoint every 5 seconds. Grafana reads from Prometheus and renders the pre-built dashboard. The dashboard is auto-provisioned via `monitoring/grafana-dashboard.json` when using the provided docker-compose stack.
+
+---
+
+## Available Metrics
+
+All metrics are exposed at `GET /metrics` in Prometheus text format. The service uses the `prom-client` library and includes Node.js default metrics prefixed with `stellar_footprint_service_`.
+
+### HTTP Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `http_requests_total` | Counter | `method`, `route`, `status_code`, `network` | Total HTTP requests handled |
+| `http_request_duration_seconds` | Histogram | `method`, `route`, `network` | Request duration; buckets: 1ms–5s |
+
+**Key derived queries**
+
+```promql
+# Request rate (req/s over 5 min)
+rate(http_requests_total{job="stellar-footprint-service"}[5m])
+
+# Error rate (%) over 5 min
+(
+  rate(http_requests_total{status_code=~"[45].."}[5m])
+  / rate(http_requests_total[5m])
+) * 100
+
+# P95 latency
+histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
+```
+
+### Simulation Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `simulate_requests_total` | Counter | `network`, `status` (`success`/`failure`) | Simulation attempts by outcome |
+| `simulate_duration_seconds` | Histogram | `network` | End-to-end simulation latency; buckets: 100ms–30s |
+| `active_simulations` | Gauge | — | Currently in-flight simulations |
+| `simulate_request_xdr_bytes` | Histogram | — | Raw XDR payload size; buckets: 256B–64KB |
+| `simulate_footprint_entries` | Histogram | `type` | Footprint entries per simulation; buckets: 0–100 |
+
+### Cache Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `cache_hits_total` | Counter | `cache_type` | Cache hits (label value: `simulation`) |
+| `cache_misses_total` | Counter | `cache_type` | Cache misses |
+| `cache_operation_duration_seconds` | Histogram | `operation` (`get`/`set`), `backend` | Cache latency; buckets: 0.5ms–500ms |
+
+**Key derived query**
+
+```promql
+# Cache hit rate (%)
+(
+  rate(cache_hits_total[5m])
+  / (rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]))
+) * 100
+```
+
+### RPC / Infrastructure Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `rpc_errors_total` | Counter | `network`, `error_type` | RPC errors by network and error category |
+
+### Node.js Default Metrics (auto-collected)
+
+All standard `prom-client` default metrics are exposed with the `stellar_footprint_service_` prefix, including:
+
+- `stellar_footprint_service_process_cpu_seconds_total`
+- `stellar_footprint_service_process_resident_memory_bytes`
+- `stellar_footprint_service_nodejs_eventloop_lag_seconds`
+- `stellar_footprint_service_nodejs_heap_size_used_bytes`
+- `stellar_footprint_service_nodejs_active_handles_total`
+
+---
+
+## Starting the Monitoring Stack
+
+### Docker Compose (recommended)
+
+```bash
+# Start the full stack: service + Prometheus + Grafana + Redis
+docker-compose -f docker-compose.prod.yml up -d
+
+# Verify all containers are running
+docker-compose -f docker-compose.prod.yml ps
+
+# Confirm the service exposes metrics
+curl http://localhost:3000/metrics | head -20
+```
+
+Access points:
+
+| Service | URL | Default credentials |
+|---|---|---|
+| Stellar Service | http://localhost:3000 | — |
+| Prometheus | http://localhost:9090 | — |
+| Grafana | http://localhost:3001 | `admin` / `admin` |
+
+**Change the Grafana password before exposing to the internet.**
+
+### Kubernetes
+
+The service exposes `/metrics` on port `3000`. Add a `ServiceMonitor` (if using the Prometheus Operator) pointing at that port:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: stellar-footprint-service
+spec:
+  selector:
+    matchLabels:
+      app: stellar-footprint-service
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 5s
+```
+
+---
+
+## Grafana Dashboard Import
+
+The pre-built dashboard is auto-provisioned when using the docker-compose stack. To import it manually:
+
+1. Open Grafana → **Dashboards** → **Import**
+2. Click **Upload JSON file**
+3. Select `monitoring/grafana-dashboard.json`
+4. Choose **Prometheus** as the data source
+5. Click **Import**
+
+The dashboard includes panels for: request rate, error rate, P50/P95/P99 latency, cache hit rate, active simulations, and status code distribution.
+
+---
+
+## Key Metrics to Watch
+
+| Metric | Target | Alert threshold |
+|---|---|---|
+| Error rate (`4xx`+`5xx`) | < 1% | > 5% for 2 min |
+| P95 request latency | < 500 ms | > 1 s for 5 min |
+| Cache hit rate | > 80% | < 50% for 10 min |
+| `active_simulations` | < 50 | > 100 sustained |
+| Event loop lag | < 100 ms | > 500 ms |
+| Heap used | < 70% of limit | > 85% of limit |
+
+---
+
+## Alerting Recommendations
+
+Add these alert rules to Prometheus (`prometheus.yml` → `rule_files`):
+
+```yaml
+groups:
+  - name: stellar-footprint-service
+    rules:
+      - alert: HighErrorRate
+        expr: |
+          (
+            rate(http_requests_total{job="stellar-footprint-service", status_code=~"5.."}[5m])
+            / rate(http_requests_total{job="stellar-footprint-service"}[5m])
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate > 5% for 2 minutes"
+
+      - alert: HighLatencyP95
+        expr: |
+          histogram_quantile(
+            0.95,
+            rate(http_request_duration_seconds_bucket{job="stellar-footprint-service"}[5m])
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 latency > 1 s for 5 minutes"
+
+      - alert: LowCacheHitRate
+        expr: |
+          (
+            rate(cache_hits_total[5m])
+            / (rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]))
+          ) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Cache hit rate below 50% for 10 minutes"
+
+      - alert: RpcErrorSpike
+        expr: rate(rpc_errors_total[5m]) > 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RPC error rate > 1/s — circuit breaker may open"
+
+      - alert: ServiceDown
+        expr: up{job="stellar-footprint-service"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Stellar Footprint Service is unreachable"
+```
+
+---
+
+## Troubleshooting
+
+### Prometheus shows the target as `DOWN`
+
+1. Check the target list at http://localhost:9090/targets
+2. Confirm the service is running: `curl http://localhost:3000/health`
+3. Confirm metrics are exposed: `curl http://localhost:3000/metrics`
+4. Check network connectivity between the Prometheus and service containers
+
+### No data in Grafana panels
+
+1. Confirm Prometheus data source is configured (Grafana → **Connections** → **Data sources**)
+2. Run a raw query in Prometheus to verify metrics exist: `http_requests_total`
+3. Check the Grafana time range — new deployments have no history; zoom in to "Last 5 minutes"
+
+### Container fails to start
+
+```bash
+# Inspect logs for all services
+docker-compose -f docker-compose.prod.yml logs --tail=50
+
+# Check the service specifically
+docker-compose -f docker-compose.prod.yml logs stellar-footprint-service
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GRAFANA_USER` | `admin` | Grafana admin username |
+| `GRAFANA_PASSWORD` | `admin` | Grafana admin password — **change in production** |
+
+---
+
+## Further Reading
+
+- [Prometheus configuration reference](monitoring/prometheus.yml)
+- [Grafana dashboard JSON](monitoring/grafana-dashboard.json)
+- [Monitoring quick start](monitoring/QUICK_START.md)
+- [Architecture overview](../architecture.md)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,18 +18,22 @@ tags:
   - name: simulation
     description: Transaction simulation and footprint extraction
   - name: utilities
-    description: XDR decoding and health checks
+    description: XDR decoding, health checks, and cache management
+  - name: network
+    description: Network status and information
 
 paths:
   /health:
     get:
       tags: [utilities]
-      summary: Liveness check
-      description: Returns service health status. Used by load balancers and uptime monitors.
+      summary: Liveness check (deprecated alias)
+      description: |
+        Returns service liveness status. Deprecated — use `/health/live` instead.
+        Kept for backwards compatibility with load balancers and uptime monitors.
       operationId: getHealth
       responses:
         "200":
-          description: Service is healthy
+          description: Service is running
           content:
             application/json:
               schema:
@@ -40,6 +44,76 @@ paths:
                 version: 1.0.0
                 timestamp: "2024-01-01T00:00:00.000Z"
 
+  /health/live:
+    get:
+      tags: [utilities]
+      summary: Liveness check
+      description: |
+        Returns service liveness status. Use this endpoint with Kubernetes `livenessProbe`
+        and load-balancer health checks.
+      operationId: getLiveness
+      responses:
+        "200":
+          description: Process is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                uptime: 123.45
+                version: 1.0.0
+                timestamp: "2024-01-01T00:00:00.000Z"
+
+  /health/ready:
+    get:
+      tags: [utilities]
+      summary: Readiness check
+      description: |
+        Returns readiness status. Checks whether the cache backend and RPC circuit breaker
+        are healthy. Use with Kubernetes `readinessProbe` — traffic is only sent to pods
+        that return `200` here.
+      operationId: getReadiness
+      responses:
+        "200":
+          description: Service is ready to accept traffic
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+              example:
+                status: ready
+                checks:
+                  cache:
+                    status: healthy
+                    details:
+                      backend: redis
+                  rpcCircuitBreaker:
+                    status: healthy
+                    details:
+                      state: closed
+                      failureCount: 0
+                timestamp: "2024-01-01T00:00:00.000Z"
+        "503":
+          description: Service is not ready (cache or RPC unhealthy)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+              example:
+                status: not ready
+                checks:
+                  cache:
+                    status: unhealthy
+                    details:
+                      error: "Connection refused"
+                  rpcCircuitBreaker:
+                    status: healthy
+                    details:
+                      state: closed
+                      failureCount: 0
+                timestamp: "2024-01-01T00:00:00.000Z"
+
   /simulate:
     post:
       tags: [simulation]
@@ -48,6 +122,9 @@ paths:
         Submits a transaction XDR to the Stellar RPC `simulateTransaction` endpoint,
         extracts the footprint (read-only and read-write ledger keys), and returns
         resource cost estimates.
+
+        Results are cached by a hash of the request body. The `X-Cache` response header
+        indicates whether the result was served from cache (`HIT`) or freshly simulated (`MISS`).
       operationId: simulate
       requestBody:
         required: true
@@ -61,6 +138,12 @@ paths:
       responses:
         "200":
           description: Simulation succeeded
+          headers:
+            X-Cache:
+              description: Whether the result was served from cache
+              schema:
+                type: string
+                enum: [HIT, MISS]
           content:
             application/json:
               schema:
@@ -74,13 +157,7 @@ paths:
                   cpuInsns: "1234567"
                   memBytes: "8192"
         "400":
-          description: Missing or invalid request body
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-              example:
-                error: "Missing required field: xdr"
+          $ref: "#/components/responses/BadRequest"
         "422":
           description: Simulation failed (contract error or restoration required)
           content:
@@ -99,44 +176,214 @@ paths:
                     success: false
                     error: "Transaction requires ledger entry restoration before simulation."
         "429":
-          description: Rate limit exceeded
-          headers:
-            X-RateLimit-Limit:
-              description: Maximum number of requests allowed in the current window
-              schema:
-                type: integer
-              example: 60
-            X-RateLimit-Remaining:
-              description: Number of requests remaining in the current window
-              schema:
-                type: integer
-              example: 0
-            X-RateLimit-Reset:
-              description: Unix timestamp (seconds) when the current rate-limit window resets
-              schema:
-                type: integer
-              example: 1700000060
-            Retry-After:
-              description: Number of seconds to wait before retrying
-              schema:
-                type: integer
-              example: 60
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-              example:
-                error: "Too Many Requests"
-                message: "Rate limit exceeded. Try again in 60 seconds."
-                retryAfter: 60
+          $ref: "#/components/responses/TooManyRequests"
         "500":
-          description: Internal server error
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /simulate/batch:
+    post:
+      tags: [simulation]
+      summary: Simulate multiple Soroban transactions
+      description: |
+        Simulates up to 10 transactions concurrently. Each transaction is processed
+        independently; failures in one entry do not affect others.
+
+        The `X-Cache` header reflects aggregate cache status: `HIT` (all cached),
+        `PARTIAL` (some cached), or `MISS` (none cached).
+      operationId: simulateBatch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimulateBatchRequest"
+            example:
+              transactions:
+                - xdr: "AAAAAgAAAAC..."
+                - xdr: "AAAAAgAAAAD..."
+              network: testnet
+      responses:
+        "200":
+          description: Batch processed (individual results may contain errors)
+          headers:
+            X-Cache:
+              description: Aggregate cache status across all results
+              schema:
+                type: string
+                enum: [HIT, PARTIAL, MISS]
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/SimulateBatchResponse"
               example:
-                error: "Unexpected error"
+                results:
+                  - index: 0
+                    success: true
+                    footprint:
+                      readOnly: ["AAAABgAAAAHZ..."]
+                      readWrite: ["AAAABgAAAAHb..."]
+                    cost:
+                      cpuInsns: "1234567"
+                      memBytes: "8192"
+                  - index: 1
+                    success: false
+                    error: "contract panic: assertion failed"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /simulate/cost-breakdown:
+    get:
+      tags: [simulation]
+      summary: Detailed cost breakdown
+      description: |
+        Returns a detailed breakdown of Soroban resource fees given raw CPU instruction
+        and memory byte counts. Useful for building fee estimation UIs without running
+        a full simulation.
+      operationId: getCostBreakdown
+      parameters:
+        - name: cpuInsns
+          in: query
+          required: true
+          description: CPU instructions count (non-negative integer string)
+          schema:
+            type: string
+            example: "1234567"
+        - name: memBytes
+          in: query
+          required: true
+          description: Memory bytes count (non-negative integer string)
+          schema:
+            type: string
+            example: "8192"
+        - name: network
+          in: query
+          required: false
+          description: Stellar network to use for fee parameters
+          schema:
+            type: string
+            enum: [testnet, mainnet, futurenet]
+            default: testnet
+      responses:
+        "200":
+          description: Cost breakdown calculated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CostBreakdownResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /network/status:
+    get:
+      tags: [network]
+      summary: Network status
+      description: |
+        Returns current Stellar network information including the latest ledger sequence
+        and network passphrase. Response is cached for 10 seconds.
+      operationId: getNetworkStatus
+      parameters:
+        - name: network
+          in: query
+          required: false
+          description: Network to query
+          schema:
+            type: string
+            enum: [testnet, mainnet, futurenet]
+            default: testnet
+      responses:
+        "200":
+          description: Network status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NetworkStatusResponse"
+              example:
+                success: true
+                data:
+                  latestLedger: 12345678
+                  passphrase: "Test SDF Network ; September 2015"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /footprint/diff:
+    post:
+      tags: [simulation]
+      summary: Compare two footprints
+      description: |
+        Compares two footprints and returns the difference (entries added, removed, or
+        changed between reads). Useful for auditing how a contract update changes its
+        ledger access pattern.
+      operationId: footprintDiff
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FootprintDiffRequest"
+            example:
+              before:
+                readOnly: ["AAAABgAAAAHZ..."]
+                readWrite: ["AAAABgAAAAHb..."]
+              after:
+                readOnly: ["AAAABgAAAAHZ...", "AAAABgAAAAHc..."]
+                readWrite: []
+      responses:
+        "200":
+          description: Diff computed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /validate:
+    post:
+      tags: [utilities]
+      summary: Validate transaction XDR
+      description: |
+        Validates a transaction XDR without simulating it against the network.
+        Use this to detect structural issues (malformed XDR, missing fields) before
+        incurring the cost of a full simulation.
+      operationId: validateXdr
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimulateRequest"
+            example:
+              xdr: "AAAAAgAAAAC..."
+              network: testnet
+      responses:
+        "200":
+          description: XDR is valid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeResponse"
+              example:
+                success: true
+                data:
+                  message: "XDR is valid"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /decode:
     get:
@@ -145,6 +392,8 @@ paths:
       description: |
         Decodes a base64-encoded XDR string into a human-readable JSON representation.
         Useful for debugging transaction structures and ledger entries.
+
+        Supported `type` values: `transaction`, `operation`, `ledger_key`.
       operationId: decodeXdr
       parameters:
         - name: xdr
@@ -158,11 +407,12 @@ paths:
           in: query
           required: false
           description: |
-            XDR type hint for decoding. If omitted the service will attempt
-            auto-detection. Common values: `transaction`, `ledgerEntry`, `operationResult`.
+            XDR type for decoding. Defaults to `transaction`.
+            Supported values: `transaction`, `operation`, `ledger_key`.
           schema:
             type: string
-            example: transaction
+            enum: [transaction, operation, ledger_key]
+            default: transaction
       responses:
         "200":
           description: XDR decoded successfully
@@ -171,35 +421,248 @@ paths:
               schema:
                 $ref: "#/components/schemas/DecodeResponse"
               example:
+                success: true
                 type: transaction
                 decoded:
                   fee: 100
                   operations: []
         "400":
-          description: Missing or invalid XDR parameter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-              example:
-                error: "Missing required query parameter: xdr"
-        "422":
-          description: XDR could not be decoded
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-              example:
-                error: "Failed to decode XDR: invalid base64"
+          $ref: "#/components/responses/BadRequest"
         "500":
-          description: Internal server error
+          $ref: "#/components/responses/InternalServerError"
+
+  /restore:
+    post:
+      tags: [simulation]
+      summary: Build a ledger entry restoration transaction
+      description: |
+        Builds a restoration transaction for expired ledger entries referenced by the
+        provided XDR. Submit this transaction to the network before retrying `/simulate`
+        when you receive a `422` with `"restoration required"`.
+      operationId: restore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestoreRequest"
+            example:
+              xdr: "AAAAAgAAAAC..."
+              network: testnet
+      responses:
+        "200":
+          description: Restoration transaction built successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/EnvelopeResponse"
+              example:
+                success: true
+                data:
+                  restoreXdr: "AAAAAgAAAAD..."
+                  network: testnet
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /estimate-fee:
+    post:
+      tags: [simulation]
+      summary: Estimate transaction fee
+      description: |
+        Returns a fee estimate given raw resource usage values (`cpuInsns`, `memBytes`).
+        Use the values from a `/simulate` response to compute the fee before building
+        and signing the final transaction.
+      operationId: estimateFee
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EstimateFeeRequest"
+            example:
+              cpuInsns: "1234567"
+              memBytes: "8192"
+              network: testnet
+      responses:
+        "200":
+          description: Fee estimate calculated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EstimateFeeResponse"
+              example:
+                inclusionFee: "100"
+                resourceFee: "850"
+                totalFee: "950"
+                network: testnet
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /cache:
+    delete:
+      tags: [utilities]
+      summary: Flush simulation cache
+      description: |
+        Flushes all entries from the simulation cache (Redis or in-memory LRU depending
+        on configuration). Use this to force fresh simulations after a contract upgrade
+        or network parameter change.
+      operationId: invalidateCache
+      responses:
+        "200":
+          description: Cache flushed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CacheInvalidateResponse"
+              example:
+                message: "Cache invalidated"
+                backend: redis
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /openapi.json:
+    get:
+      tags: [utilities]
+      summary: OpenAPI specification (JSON)
+      description: Serves the raw OpenAPI specification as JSON.
+      operationId: getOpenApiSpec
+      responses:
+        "200":
+          description: OpenAPI specification
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
 
 components:
+  responses:
+    BadRequest:
+      description: Missing or invalid request parameters
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvelopeErrorResponse"
+          example:
+            success: false
+            error: "Missing required field: xdr"
+
+    TooManyRequests:
+      description: Rate limit exceeded
+      headers:
+        RateLimit-Limit:
+          description: Maximum requests allowed in the window
+          schema:
+            type: integer
+          example: 60
+        RateLimit-Remaining:
+          description: Requests remaining in the current window
+          schema:
+            type: integer
+          example: 0
+        RateLimit-Reset:
+          description: Unix timestamp (seconds) when the window resets
+          schema:
+            type: integer
+          example: 1700000060
+        X-RateLimit-Limit:
+          description: Legacy alias for RateLimit-Limit
+          schema:
+            type: integer
+        X-RateLimit-Remaining:
+          description: Legacy alias for RateLimit-Remaining
+          schema:
+            type: integer
+        X-RateLimit-Reset:
+          description: Legacy alias for RateLimit-Reset
+          schema:
+            type: integer
+        Retry-After:
+          description: Seconds to wait before retrying
+          schema:
+            type: integer
+          example: 60
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RateLimitErrorResponse"
+          example:
+            error: "Too Many Requests"
+            message: "Rate limit exceeded. Try again in 60 seconds."
+            retryAfter: 60
+
+    InternalServerError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvelopeErrorResponse"
+          example:
+            success: false
+            error: "Unexpected error"
+
+    ServiceUnavailable:
+      description: RPC circuit breaker is open; service temporarily unavailable
+      headers:
+        Retry-After:
+          description: Seconds until the circuit breaker attempts recovery
+          schema:
+            type: integer
+          example: 28
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvelopeErrorResponse"
+          example:
+            success: false
+            error: "RPC circuit breaker is open. Try again later."
+
   schemas:
+    # ── Shared envelope ──────────────────────────────────────────────────────
+    EnvelopeResponse:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        data:
+          description: Response payload (shape varies by endpoint)
+          additionalProperties: true
+
+    EnvelopeErrorResponse:
+      type: object
+      required: [success, error]
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: string
+          description: Human-readable error message
+
+    RateLimitErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          example: "Too Many Requests"
+        message:
+          type: string
+          description: Extended message with retry guidance
+          example: "Rate limit exceeded. Try again in 60 seconds."
+        retryAfter:
+          type: integer
+          description: Seconds to wait before retrying
+          example: 60
+
+    # ── Health ───────────────────────────────────────────────────────────────
     HealthResponse:
       type: object
       required: [status, uptime, timestamp]
@@ -217,6 +680,45 @@ components:
           type: string
           format: date-time
 
+    ReadinessResponse:
+      type: object
+      required: [status, checks, timestamp]
+      properties:
+        status:
+          type: string
+          enum: [ready, "not ready"]
+        checks:
+          type: object
+          properties:
+            cache:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [healthy, unhealthy]
+                details:
+                  type: object
+                  additionalProperties: true
+            rpcCircuitBreaker:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [healthy, unhealthy]
+                details:
+                  type: object
+                  additionalProperties: true
+        timestamp:
+          type: string
+          format: date-time
+
+    # ── Simulation ───────────────────────────────────────────────────────────
+    Network:
+      type: string
+      enum: [testnet, mainnet, futurenet]
+      default: testnet
+      description: Stellar network to use
+
     SimulateRequest:
       type: object
       required: [xdr]
@@ -226,16 +728,30 @@ components:
           description: Base64-encoded Soroban transaction XDR
           example: "AAAAAgAAAAC..."
         network:
-          type: string
-          enum: [testnet, mainnet]
-          default: testnet
-          description: Stellar network to simulate against
+          $ref: "#/components/schemas/Network"
         ledgerSequence:
           type: integer
-          description: |
-            Optional ledger sequence to simulate against.
-            Useful for reproducing historical simulation results.
+          description: Optional ledger sequence to simulate against (for reproducibility)
           example: 12345678
+
+    SimulateBatchRequest:
+      type: object
+      required: [transactions]
+      properties:
+        transactions:
+          type: array
+          items:
+            type: object
+            required: [xdr]
+            properties:
+              xdr:
+                type: string
+                description: Base64-encoded Soroban transaction XDR
+          minItems: 1
+          maxItems: 10
+          description: Array of transactions to simulate (maximum 10)
+        network:
+          $ref: "#/components/schemas/Network"
 
     Footprint:
       type: object
@@ -258,11 +774,11 @@ components:
       properties:
         cpuInsns:
           type: string
-          description: CPU instructions consumed (as string to avoid precision loss)
+          description: CPU instructions consumed (string to avoid precision loss)
           example: "1234567"
         memBytes:
           type: string
-          description: Memory bytes consumed (as string to avoid precision loss)
+          description: Memory bytes consumed (string to avoid precision loss)
           example: "8192"
 
     SimulateSuccessResponse:
@@ -276,6 +792,9 @@ components:
           $ref: "#/components/schemas/Footprint"
         cost:
           $ref: "#/components/schemas/ResourceCost"
+        cacheHit:
+          type: boolean
+          description: Whether the result was served from cache
 
     SimulateFailureResponse:
       type: object
@@ -288,18 +807,135 @@ components:
           type: string
           description: Human-readable error message from the simulation
 
+    SimulateBatchResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          items:
+            oneOf:
+              - allOf:
+                  - $ref: "#/components/schemas/SimulateSuccessResponse"
+                  - type: object
+                    required: [index]
+                    properties:
+                      index:
+                        type: integer
+              - allOf:
+                  - $ref: "#/components/schemas/SimulateFailureResponse"
+                  - type: object
+                    required: [index]
+                    properties:
+                      index:
+                        type: integer
+
+    # ── Cost breakdown ───────────────────────────────────────────────────────
+    CostBreakdownResponse:
+      type: object
+      description: Detailed breakdown of Soroban resource fees
+
+    # ── Network status ───────────────────────────────────────────────────────
+    NetworkStatusResponse:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          properties:
+            latestLedger:
+              type: integer
+              description: Latest closed ledger sequence
+            passphrase:
+              type: string
+              description: Network passphrase
+
+    # ── Footprint diff ───────────────────────────────────────────────────────
+    FootprintDiffRequest:
+      type: object
+      required: [before, after]
+      properties:
+        before:
+          $ref: "#/components/schemas/Footprint"
+        after:
+          $ref: "#/components/schemas/Footprint"
+
+    # ── Decode ───────────────────────────────────────────────────────────────
     DecodeResponse:
       type: object
-      required: [type, decoded]
+      required: [success, type, decoded]
       properties:
+        success:
+          type: boolean
         type:
           type: string
-          description: Detected or provided XDR type
+          description: XDR type used for decoding
+          enum: [transaction, operation, ledger_key]
         decoded:
           type: object
           description: Human-readable JSON representation of the XDR
           additionalProperties: true
 
+    # ── Restore ──────────────────────────────────────────────────────────────
+    RestoreRequest:
+      type: object
+      required: [xdr]
+      properties:
+        xdr:
+          type: string
+          description: Base64-encoded Soroban transaction XDR that requires restoration
+          example: "AAAAAgAAAAC..."
+        network:
+          $ref: "#/components/schemas/Network"
+
+    # ── Fee estimation ───────────────────────────────────────────────────────
+    EstimateFeeRequest:
+      type: object
+      required: [cpuInsns, memBytes]
+      properties:
+        cpuInsns:
+          type: string
+          description: CPU instructions (non-negative integer string)
+          example: "1234567"
+        memBytes:
+          type: string
+          description: Memory bytes (non-negative integer string)
+          example: "8192"
+        network:
+          $ref: "#/components/schemas/Network"
+
+    EstimateFeeResponse:
+      type: object
+      properties:
+        inclusionFee:
+          type: string
+          description: Base inclusion fee in stroops
+        resourceFee:
+          type: string
+          description: Soroban resource fee in stroops
+        totalFee:
+          type: string
+          description: Total recommended fee in stroops
+        network:
+          type: string
+
+    # ── Cache ─────────────────────────────────────────────────────────────────
+    CacheInvalidateResponse:
+      type: object
+      required: [message, backend]
+      properties:
+        message:
+          type: string
+          example: "Cache invalidated"
+        backend:
+          type: string
+          description: Cache backend that was flushed
+          enum: [redis, memory]
+
+    # ── Legacy (kept for backwards compatibility) ─────────────────────────────
     ErrorResponse:
       type: object
       required: [error]


### PR DESCRIPTION
## Summary

- **ADR 003** (`docs/adr/003-rate-limiting.md`): Documents the two-layer rate limiting design — `express-rate-limit` for volumetric caps on `/simulate` and an in-process brute-force tracker with delay/block thresholds. Covers all env vars, in-memory vs Redis trade-offs, and alternatives considered.
- **Error Handling Guide** (`docs/guides/error-handling.md`): Full API consumer reference covering every status code (400, 401, 422, 429, 500, 503), example responses, rate-limit headers, brute-force block behaviour, i18n note, and retry recommendations.
- **Monitoring Guide** (`docs/guides/monitoring.md`): Production operator guide covering all Prometheus metrics exposed by `metrics.ts`, Grafana dashboard import, key metrics table, four ready-to-paste Prometheus alert rules, and troubleshooting steps. Linked from README.
- **OpenAPI spec audit** (`openapi.yaml`): Added 10 previously undocumented endpoints (`/health/live`, `/health/ready`, `/simulate/batch`, `/simulate/cost-breakdown`, `/network/status`, `/footprint/diff`, `/validate`, `/restore`, `/estimate-fee`, `/cache`). Added shared `responses` components for 400/429/500/503, fixed `Network` enum to include `futurenet`, updated `decode` type enum to match implementation. Validated with `swagger-cli validate`.

## Test plan

- [ ] `npx @apidevtools/swagger-cli validate openapi.yaml` passes (already verified locally)
- [ ] All linked guide paths resolve correctly from README
- [ ] ADR 003 index in `docs/adr/README.md` lists the new entry
- [ ] All new routes in `routes.ts` are now represented in `openapi.yaml`

Closes #388 
Closes #389 
Closes #390 
Closes #391 

🤖 Generated with [Claude Code](https://claude.com/claude-code)