### PR TITLE
dx: configure nodemon to watch all TypeScript source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,10 @@ cp .env.example .env
 
 ```bash
 npm run dev
+npm run dev:watch
 ```
+
+`npm run dev:watch` uses `nodemon` and the project's `nodemon.json` configuration to restart automatically on `src/**/*.ts` changes.
 
 ### Production Build
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["src"],
+  "watch": ["src/**/*.ts"],
   "ext": "ts",
   "ignore": ["src/**/*.test.ts", "src/**/*.spec.ts"],
   "exec": "ts-node",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "env:check": "node scripts/check-env.js",
     "start": "npm run env:check && node -r tsconfig-paths/register dist/index.js",
     "dev": "ts-node -r tsconfig-paths/register src/index.ts",
+    "dev:watch": "nodemon",
     "pm2:start": "pm2 start ecosystem.config.js --env production",
     "pm2:start:staging": "pm2 start ecosystem.config.js --env staging",
     "pm2:stop": "pm2 stop stellar-footprint-service",
@@ -71,6 +72,7 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
+    "nodemon": "^3.0.2",
     "typescript": "^6.0.3",
     "validate-branch-name": "^1.3.2"
   },


### PR DESCRIPTION
## Updates made

- package.json
  - Added `dev:watch` script alias: `nodemon`
  - Added `nodemon` to `devDependencies`

- nodemon.json
  - Changed watcher to `"watch": ["src/**/*.ts"]`
  - Keeps `ext: "ts"` so source changes trigger restart

- README.md
  - Documented `npm run dev:watch`
  - Noted that it uses `nodemon` and restarts on `src/**/*.ts` changes

Made changes.

Closes #377 