### PR TITLE
dx: add typecheck script and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm run lint
 
       - name: Type-check
-        run: npx tsc --noEmit
+        run: pnpm run typecheck
 
       - name: Test
         run: pnpm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 |---|---|
 | `pnpm run dev` | Start dev server with hot reload |
 | `pnpm run build` | Compile TypeScript |
+| `pnpm run typecheck` | Run TypeScript type checking without emitting files |
 | `pnpm run start` | Start production server |
 | `pnpm run lint` | Run ESLint |
 | `pnpm run lint:fix` | Auto-fix lint issues |
@@ -178,6 +179,7 @@ chore(deps): update @stellar/stellar-sdk to 12.1.0
 2. **Run all checks locally:**
    ```bash
    pnpm run lint
+   pnpm run typecheck
    pnpm run format:check
    pnpm run build
    pnpm test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist coverage",
     "build:clean": "npm run clean && npm run build",
     "env:check": "node scripts/check-env.js",


### PR DESCRIPTION
✅ Implemented the requested changes:

- Added `typecheck: "tsc --noEmit"` to package.json scripts.
- Updated ci.yml to run `pnpm run typecheck` before `pnpm run build`.
- Documented the new script in CONTRIBUTING.md and included it in the local checks checklist.

Made changes.

Closes #378 