### PR TITLE
test: add unit and integration tests for middleware, cache, and batch

### DIFF
--- a/src/__tests__/batch.simulate.integration.test.ts
+++ b/src/__tests__/batch.simulate.integration.test.ts
@@ -1,0 +1,143 @@
+import { simulateTransaction } from "@services/simulator";
+import request from "supertest";
+
+import { BATCH_MAX_SIZE } from "../constants";
+import app from "../index";
+
+jest.mock("@services/simulator", () => ({
+  simulateTransaction: jest.fn(),
+  simulationCache: { get: jest.fn(), set: jest.fn() },
+}));
+
+jest.mock("@middleware/metrics", () => ({
+  __esModule: true,
+  default: {
+    incrementActiveSimulations: jest.fn(),
+    decrementActiveSimulations: jest.fn(),
+    recordSimulation: jest.fn(),
+    recordSimulationDuration: jest.fn(),
+    recordCacheHit: jest.fn(),
+    recordCacheMiss: jest.fn(),
+    recordRpcError: jest.fn(),
+    recordCacheLatency: jest.fn(),
+    getMetrics: jest.fn().mockResolvedValue(""),
+  },
+  metricsMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  metrics: { getMetrics: jest.fn().mockResolvedValue("") },
+}));
+
+const mockSimulate = simulateTransaction as jest.MockedFunction<
+  typeof simulateTransaction
+>;
+
+const VALID_XDR = "AAAAAgAAAAC" + "A".repeat(40) + "==";
+
+const makeResult = (cacheHit = false) => ({
+  success: true,
+  footprint: { readOnly: [], readWrite: [] },
+  contracts: [],
+  contractType: "unknown" as const,
+  ttl: {},
+  optimized: false,
+  rawFootprint: { readOnly: [], readWrite: [] },
+  cost: { cpuInsns: "100", memBytes: "200" },
+  cacheHit,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/v1/simulate/batch — validation", () => {
+  it("returns 400 when transactions array is empty", async () => {
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions: [], network: "testnet" });
+
+    expect(res.status).toBe(400);
+    expect(mockSimulate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when transactions field is missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ network: "testnet" });
+
+    expect(res.status).toBe(400);
+    expect(mockSimulate).not.toHaveBeenCalled();
+  });
+
+  it(`returns 400 when batch exceeds max size of ${BATCH_MAX_SIZE}`, async () => {
+    const transactions = Array.from({ length: BATCH_MAX_SIZE + 1 }, () => ({
+      xdr: VALID_XDR,
+    }));
+
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions, network: "testnet" });
+
+    expect(res.status).toBe(400);
+    expect(mockSimulate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/v1/simulate/batch — mixed success/failure results", () => {
+  it("returns success and failure entries without aborting the batch", async () => {
+    mockSimulate
+      .mockResolvedValueOnce(makeResult() as never)
+      .mockRejectedValueOnce(new Error("RPC timeout"))
+      .mockResolvedValueOnce(makeResult() as never);
+
+    const transactions = Array.from({ length: 3 }, () => ({ xdr: VALID_XDR }));
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions, network: "testnet" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(3);
+    expect(res.body.results[0]).toMatchObject({ success: true });
+    expect(res.body.results[1]).toMatchObject({
+      success: false,
+      error: "RPC timeout",
+    });
+    expect(res.body.results[2]).toMatchObject({ success: true });
+  });
+});
+
+describe("POST /api/v1/simulate/batch — X-Cache header", () => {
+  it("sets X-Cache: MISS when no results are cache hits", async () => {
+    mockSimulate.mockResolvedValue(makeResult(false) as never);
+
+    const transactions = [{ xdr: VALID_XDR }, { xdr: VALID_XDR }];
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions, network: "testnet" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-cache"]).toBe("MISS");
+  });
+
+  it("sets X-Cache: PARTIAL when some results are cache hits", async () => {
+    mockSimulate
+      .mockResolvedValueOnce(makeResult(true) as never)
+      .mockResolvedValueOnce(makeResult(false) as never);
+
+    const transactions = [{ xdr: VALID_XDR }, { xdr: VALID_XDR }];
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions, network: "testnet" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-cache"]).toBe("PARTIAL");
+  });
+
+  it("sets X-Cache: HIT when all results are cache hits", async () => {
+    mockSimulate.mockResolvedValue(makeResult(true) as never);
+
+    const transactions = [{ xdr: VALID_XDR }, { xdr: VALID_XDR }];
+    const res = await request(app)
+      .post("/api/v1/simulate/batch")
+      .send({ transactions, network: "testnet" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-cache"]).toBe("HIT");
+  });
+});

--- a/src/middleware/bruteForce.test.ts
+++ b/src/middleware/bruteForce.test.ts
@@ -1,0 +1,101 @@
+import type { NextFunction, Request, Response } from "express";
+
+const makeReq = (ip: string): Request =>
+  ({ ip, socket: { remoteAddress: ip } }) as unknown as Request;
+
+const makeRes = (): Response => {
+  const res = {} as Response;
+  (res as unknown as Record<string, unknown>).status = jest
+    .fn()
+    .mockReturnValue(res);
+  (res as unknown as Record<string, unknown>).json = jest
+    .fn()
+    .mockReturnValue(res);
+  return res;
+};
+
+// Low thresholds and short window to keep tests fast.
+const ENV_OVERRIDES = {
+  BRUTE_FORCE_DELAY_THRESHOLD: "2",
+  BRUTE_FORCE_BLOCK_THRESHOLD: "4",
+  BRUTE_FORCE_WINDOW_MS: "200",
+  BRUTE_FORCE_DELAY_MS: "50",
+  BRUTE_FORCE_BLOCK_MS: "60000",
+};
+
+describe("bruteForceMiddleware", () => {
+  let bruteForceMiddleware: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<void>;
+  let recordFailure: (ip: string) => void;
+
+  beforeEach(() => {
+    Object.assign(process.env, ENV_OVERRIDES);
+    jest.resetModules();
+    const mod = require("./bruteForce");
+    bruteForceMiddleware = mod.bruteForceMiddleware;
+    recordFailure = mod.recordFailure;
+  });
+
+  afterEach(() => {
+    Object.keys(ENV_OVERRIDES).forEach((k) => delete process.env[k]);
+    jest.useRealTimers();
+  });
+
+  it("passes through immediately when below delay threshold", async () => {
+    const next = jest.fn();
+    await bruteForceMiddleware(makeReq("10.0.0.1"), makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests above delay threshold are delayed then calls next", async () => {
+    jest.useFakeTimers();
+    const ip = "10.0.0.2";
+    recordFailure(ip);
+    recordFailure(ip); // count = 2 >= DELAY_THRESHOLD
+
+    const next = jest.fn();
+    const promise = bruteForceMiddleware(makeReq(ip), makeRes(), next);
+    expect(next).not.toHaveBeenCalled(); // still awaiting the delay
+    jest.runAllTimers();
+    await promise;
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests above block threshold return 429", async () => {
+    const ip = "10.0.0.3";
+    for (let i = 0; i < 4; i++) recordFailure(ip); // count = 4 >= BLOCK_THRESHOLD
+
+    const res = makeRes();
+    const next = jest.fn();
+    await bruteForceMiddleware(makeReq(ip), res, next);
+
+    expect(
+      (res as unknown as Record<string, jest.Mock>).status,
+    ).toHaveBeenCalledWith(429);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("counter resets after window expires", async () => {
+    jest.useFakeTimers();
+    const ip = "10.0.0.4";
+    recordFailure(ip);
+    recordFailure(ip); // count = 2 >= DELAY_THRESHOLD
+
+    // Advance past the 200 ms window
+    jest.advanceTimersByTime(201);
+
+    const next = jest.fn();
+    const res = makeRes();
+    const promise = bruteForceMiddleware(makeReq(ip), res, next);
+    jest.runAllTimers();
+    await promise;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (res as unknown as Record<string, jest.Mock>).status,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/ipFilter.test.ts
+++ b/src/middleware/ipFilter.test.ts
@@ -1,0 +1,132 @@
+import type { NextFunction, Request, Response } from "express";
+
+const makeReq = (ip: string): Request =>
+  ({ ip, socket: { remoteAddress: ip } }) as unknown as Request;
+
+const makeRes = (): Response => {
+  const res = {} as Response;
+  (res as unknown as Record<string, unknown>).status = jest
+    .fn()
+    .mockReturnValue(res);
+  (res as unknown as Record<string, unknown>).json = jest
+    .fn()
+    .mockReturnValue(res);
+  return res;
+};
+
+describe("ipFilterMiddleware", () => {
+  let middleware: (req: Request, res: Response, next: NextFunction) => void;
+
+  const load = () => {
+    jest.resetModules();
+    middleware = require("./ipFilter").ipFilterMiddleware;
+  };
+
+  beforeEach(() => {
+    delete process.env.IP_ALLOWLIST;
+    delete process.env.IP_BLOCKLIST;
+  });
+
+  describe("no allowlist or blocklist configured", () => {
+    beforeEach(load);
+
+    it("allows all traffic", () => {
+      const next = jest.fn();
+      middleware(makeReq("1.2.3.4"), makeRes(), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows private-range IPs", () => {
+      const next = jest.fn();
+      middleware(makeReq("192.168.0.1"), makeRes(), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("blocked IP returns 403", () => {
+    beforeEach(() => {
+      process.env.IP_BLOCKLIST = "10.0.0.0/8";
+      load();
+    });
+
+    it("returns 403 for an IP inside the blocklist CIDR", () => {
+      const res = makeRes();
+      const next = jest.fn();
+      middleware(makeReq("10.1.2.3"), res, next);
+      expect(
+        (res as unknown as Record<string, jest.Mock>).status,
+      ).toHaveBeenCalledWith(403);
+      expect(
+        (res as unknown as Record<string, jest.Mock>).json,
+      ).toHaveBeenCalledWith({ error: "Forbidden" });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("allows an IP that is outside the blocklist CIDR", () => {
+      const next = jest.fn();
+      middleware(makeReq("172.16.0.1"), makeRes(), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("allowed IP passes through", () => {
+    beforeEach(() => {
+      process.env.IP_ALLOWLIST = "10.0.0.0/8";
+      load();
+    });
+
+    it("passes through an IP that is inside the allowlist CIDR", () => {
+      const next = jest.fn();
+      middleware(makeReq("10.5.6.7"), makeRes(), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks an IP that is not in the allowlist", () => {
+      const res = makeRes();
+      const next = jest.fn();
+      middleware(makeReq("192.168.1.1"), res, next);
+      expect(
+        (res as unknown as Record<string, jest.Mock>).status,
+      ).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("CIDR range matching", () => {
+    it("correctly includes and excludes IPs at /24 subnet boundaries", () => {
+      process.env.IP_ALLOWLIST = "192.168.1.0/24";
+      load();
+
+      const nextIn = jest.fn();
+      const nextOut = jest.fn();
+
+      middleware(makeReq("192.168.1.200"), makeRes(), nextIn);
+      expect(nextIn).toHaveBeenCalledTimes(1);
+
+      middleware(makeReq("192.168.2.1"), makeRes(), nextOut);
+      expect(nextOut).not.toHaveBeenCalled();
+    });
+
+    it("correctly matches a /32 single-host CIDR on the blocklist", () => {
+      process.env.IP_BLOCKLIST = "203.0.113.42/32";
+      load();
+
+      const nextBlocked = jest.fn();
+      const nextAllowed = jest.fn();
+
+      middleware(makeReq("203.0.113.42"), makeRes(), nextBlocked);
+      expect(nextBlocked).not.toHaveBeenCalled();
+
+      middleware(makeReq("203.0.113.43"), makeRes(), nextAllowed);
+      expect(nextAllowed).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks all IPs when blocklist contains 0.0.0.0/0", () => {
+      process.env.IP_BLOCKLIST = "0.0.0.0/0";
+      load();
+      const next = jest.fn();
+      middleware(makeReq("8.8.8.8"), makeRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/cache.test.ts
+++ b/src/services/cache.test.ts
@@ -1,0 +1,159 @@
+import { LruMemoryCache, buildCacheKey } from "./cache";
+
+jest.mock("ioredis");
+jest.mock("../middleware/metrics", () => ({
+  __esModule: true,
+  default: { recordCacheLatency: jest.fn() },
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// LruMemoryCache (synchronous)
+// ---------------------------------------------------------------------------
+
+describe("LruMemoryCache", () => {
+  it("LRU eviction: evicts the least-recently-used entry when maxSize is reached", () => {
+    const cache = new LruMemoryCache<string>(3, 60_000);
+    cache.set("a", "A");
+    cache.set("b", "B");
+    cache.set("c", "C");
+    // Access 'a' so it becomes MRU; 'b' becomes LRU
+    cache.get("a");
+    cache.set("d", "D"); // should evict 'b'
+
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("a")).toBe("A");
+    expect(cache.get("c")).toBe("C");
+    expect(cache.get("d")).toBe("D");
+  });
+
+  it("TTL expiry: returns undefined for expired entries", async () => {
+    const cache = new LruMemoryCache<string>(10, 50); // 50 ms TTL
+    cache.set("key", "value");
+    expect(cache.get("key")).toBe("value");
+
+    await new Promise((r) => setTimeout(r, 60));
+    expect(cache.get("key")).toBeUndefined();
+  });
+
+  it("flush via delete: delete removes a specific entry", () => {
+    const cache = new LruMemoryCache<number>(10, 60_000);
+    cache.set("x", 1);
+    cache.set("y", 2);
+    cache.delete("x");
+    expect(cache.get("x")).toBeUndefined();
+    expect(cache.get("y")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Async cache service — flush()
+// ---------------------------------------------------------------------------
+
+describe("async CacheService (in-memory backend)", () => {
+  let getCache: () => import("./cache").CacheService;
+  let setCache: (c: import("./cache").CacheService) => void;
+
+  beforeEach(() => {
+    delete process.env.REDIS_URL;
+    jest.resetModules();
+    jest.mock("../middleware/metrics", () => ({
+      __esModule: true,
+      default: { recordCacheLatency: jest.fn() },
+    }));
+    jest.mock("../utils/logger", () => ({
+      logger: { info: jest.fn(), warn: jest.fn() },
+    }));
+    jest.mock("ioredis");
+    const mod = require("./cache");
+    getCache = mod.getCache;
+    setCache = mod.setCache;
+  });
+
+  it("flush() clears all entries", async () => {
+    const cache = getCache();
+    await cache.set("k1", "v1", 10_000);
+    await cache.set("k2", "v2", 10_000);
+    await cache.flush();
+    expect(await cache.get("k1")).toBeNull();
+    expect(await cache.get("k2")).toBeNull();
+  });
+
+  it("backend is memory when REDIS_URL is not set", () => {
+    expect(getCache().backend).toBe("memory");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redis fallback on connection error
+// ---------------------------------------------------------------------------
+
+describe("Redis fallback on connection error", () => {
+  afterEach(() => {
+    delete process.env.REDIS_URL;
+    jest.resetModules();
+  });
+
+  it("falls back to in-memory cache when Redis emits an error", () => {
+    process.env.REDIS_URL = "redis://localhost:6379";
+    jest.resetModules();
+
+    const { EventEmitter } = require("events") as typeof import("events");
+    const fakeClient = Object.assign(new EventEmitter(), {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue("OK"),
+      del: jest.fn().mockResolvedValue(1),
+      flushdb: jest.fn().mockResolvedValue("OK"),
+    });
+
+    jest.doMock("ioredis", () => jest.fn().mockReturnValue(fakeClient));
+    jest.doMock("../middleware/metrics", () => ({
+      __esModule: true,
+      default: { recordCacheLatency: jest.fn() },
+    }));
+    jest.doMock("../utils/logger", () => ({
+      logger: { info: jest.fn(), warn: jest.fn() },
+    }));
+
+    const { getCache } = require("./cache");
+
+    const first = getCache();
+    expect(first.backend).toBe("redis");
+
+    fakeClient.emit("error", new Error("ECONNREFUSED"));
+
+    const second = getCache();
+    expect(second.backend).toBe("memory");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCacheKey
+// ---------------------------------------------------------------------------
+
+describe("buildCacheKey", () => {
+  it("produces consistent hashes for identical input", () => {
+    const a = buildCacheKey({ xdr: "abc", network: "testnet" });
+    const b = buildCacheKey({ xdr: "abc", network: "testnet" });
+    expect(a).toBe(b);
+  });
+
+  it("is order-independent (canonical key)", () => {
+    const a = buildCacheKey({ network: "testnet", xdr: "abc" });
+    const b = buildCacheKey({ xdr: "abc", network: "testnet" });
+    expect(a).toBe(b);
+  });
+
+  it("produces different hashes for different inputs", () => {
+    const a = buildCacheKey({ xdr: "abc" });
+    const b = buildCacheKey({ xdr: "xyz" });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a 64-character hex SHA-256 string", () => {
+    const key = buildCacheKey({ xdr: "abc" });
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary

- **ipFilter middleware** — allowlist, blocklist, CIDR matching, no-config pass-through
- **bruteForce middleware** — below threshold, delay threshold, block threshold (429), window reset
- **cache service** — LRU eviction, TTL expiry, flush, Redis error fallback, `buildCacheKey` hashes
- **POST /simulate/batch** — empty array 400, max-size 400, mixed results, X-Cache MISS/PARTIAL/HIT

**30 new tests across 4 files, 286 total passing.**

## Test plan

- [x] `ipFilterMiddleware` — no config allows all traffic
- [x] `ipFilterMiddleware` — blocked IP returns 403
- [x] `ipFilterMiddleware` — allowed IP passes through
- [x] `ipFilterMiddleware` — CIDR /24, /32, and 0.0.0.0/0 matching
- [x] `bruteForceMiddleware` — below threshold passes immediately
- [x] `bruteForceMiddleware` — delay threshold triggers delay then calls next
- [x] `bruteForceMiddleware` — block threshold returns 429
- [x] `bruteForceMiddleware` — counter resets after window expires
- [x] `LruMemoryCache` — LRU eviction at maxSize
- [x] `LruMemoryCache` — TTL expiry returns undefined
- [x] `LruMemoryCache` — delete removes entry
- [x] `getCache()` — flush() clears all entries
- [x] `getCache()` — Redis error falls back to in-memory
- [x] `buildCacheKey` — consistent, order-independent, 64-char hex
- [x] `POST /simulate/batch` — empty transactions → 400
- [x] `POST /simulate/batch` — batch over max size → 400
- [x] `POST /simulate/batch` — mixed success/failure results returned
- [x] `POST /simulate/batch` — X-Cache: MISS / PARTIAL / HIT

Closes #363
Closes #366
Closes #365
Closes #364

