### PR TITLE
Validate webhookUrl as HTTPS and add webhook tests

### DIFF
--- a/src/services/tests/webhook.test.ts
+++ b/src/services/tests/webhook.test.ts
@@ -1,0 +1,29 @@
+import { createJob, getJob, InvalidWebhookUrlError } from "../webhook";
+
+describe("webhook service", () => {
+  it("creates a job for a valid HTTPS webhook URL", () => {
+    const jobId = createJob("https://example.com/webhook");
+
+    expect(typeof jobId).toBe("string");
+    const job = getJob(jobId);
+    expect(job).toBeDefined();
+    expect(job?.webhookUrl).toBe("https://example.com/webhook");
+    expect(job?.status).toBe("pending");
+  });
+
+  it("rejects non-HTTPS webhook URLs", () => {
+    expect(() => createJob("http://example.com/webhook")).toThrow(
+      InvalidWebhookUrlError,
+    );
+  });
+
+  it("rejects invalid webhook URLs", () => {
+    expect(() => createJob("not-a-url")).toThrow(InvalidWebhookUrlError);
+  });
+
+  it("rejects HTTPS URLs with embedded credentials", () => {
+    expect(() => createJob("https://user:secret@example.com/webhook")).toThrow(
+      InvalidWebhookUrlError,
+    );
+  });
+});

--- a/src/services/webhook.ts
+++ b/src/services/webhook.ts
@@ -18,7 +18,12 @@ export class InvalidWebhookUrlError extends Error {
 function isValidHttpsUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:";
+    return (
+      parsed.protocol === "https:" &&
+      !!parsed.hostname &&
+      !parsed.username &&
+      !parsed.password
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
Closes #348 

This PR adds strict validation for webhookUrl to ensure only HTTPS URLs are accepted, preventing SSRF and plaintext secret leakage. It also adds tests covering valid HTTPS URLs, non-HTTPS URLs, invalid URLs, and credential-bearing URLs.